### PR TITLE
refactor(research): strip personal MCPs from baseline allowlist and prompt

### DIFF
--- a/internal/research/prompt/prompt.md
+++ b/internal/research/prompt/prompt.md
@@ -16,14 +16,13 @@ You are a research agent. Your job is to investigate the task below and emit a s
    - Code investigations (file paths, function names, error strings)
    - Bare-prose stubs (a sentence or two with no anchor)
 
-2. Use the read-only tools you have access to. MCP tools are exposed under the qualified `mcp__<server>__<tool>` form. Pick the right tool for the anchor:
-   - For Slack threads: `mcp__claude_ai_Slack__slack_read_thread` and the `mcp__claude_ai_Slack__slack_search_*` family (`slack_search_channels`, `slack_search_public`, `slack_search_public_and_private`, `slack_search_users`).
-   - For Jira: `mcp__claude_ai_Atlassian__getJiraIssue`, `mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql`.
-   - For Confluence: `mcp__claude_ai_Atlassian__getConfluencePage`, `mcp__claude_ai_Atlassian__searchConfluenceUsingCql`.
-   - For Datadog: the `mcp__claude_ai_Datadog__*` tools (logs, traces, metrics, dashboards, monitors, incidents).
-   - For institutional context (PRs, design docs, internal chat): `mcp__unblocked__context_research`, `mcp__unblocked__context_get_urls`.
-   - For GitHub: shell out to `gh` via the `Bash` tool. Read-only subcommands only — `gh issue view <ref> --comments`, `gh issue list ...`, `gh pr view <ref> --comments`, `gh pr list ...`, `gh pr diff <ref>`, and the `gh search issues|prs|code|commits|repos` family. Other gh subcommands (including `gh api`) are not authorized and will be denied.
-   - For library, framework, SDK, or CLI documentation: `mcp__context7__resolve-library-id` to find the canonical id, then `mcp__context7__query-docs` to fetch current docs. Prefer this over `WebSearch` / `WebFetch` for library docs since training data may lag.
+2. Use the read-only tools you have access to. The harness injects the available tools into your system prompt; consult that list before deciding how to investigate an anchor. Pick the most specific tool for the anchor type:
+   - For Slack threads, channels, or user lookups: prefer any read-only Slack MCP you have access to over web search.
+   - For Jira issues, JQL queries, or Confluence pages: prefer any read-only Atlassian MCP you have access to over web search.
+   - For Datadog logs, traces, metrics, dashboards, monitors, or incidents: prefer any read-only Datadog MCP you have access to.
+   - For institutional context (PRs, design docs, internal chat): prefer any institutional-knowledge MCP you have access to (e.g. an organization-wide context-research MCP).
+   - For GitHub PRs and issues: prefer a read-only GitHub MCP if available; otherwise shell out to `gh` via `Bash` using read-only subcommands only — `gh issue view <ref> --comments`, `gh issue list ...`, `gh pr view <ref> --comments`, `gh pr list ...`, `gh pr diff <ref>`, and the `gh search issues|prs|code|commits|repos` family. Never use `gh api` or any write-capable verb (`create`, `edit`, `close`, `merge`, `comment`, `delete`, `review`, `lock`, `pin`, `develop`).
+   - For library, framework, SDK, or CLI documentation: prefer an MCP-based docs lookup over `WebSearch` / `WebFetch`, since training data may lag.
    - For code: `Read`, `Glob`, `Grep`.
    - For external docs and blog posts: `WebSearch`, `WebFetch`.
 

--- a/internal/research/prompt/prompt_test.go
+++ b/internal/research/prompt/prompt_test.go
@@ -51,6 +51,48 @@ func TestLoad_missingOverrideFallsBackToEmbedded(t *testing.T) {
 	}
 }
 
+func TestEmbeddedDefault_namesNoInstallSpecificMCPsOrGhPatterns(t *testing.T) {
+	// The shipped binary cannot assume any particular MCP server is
+	// installed. Naming `mcp__claude_ai_*`, `mcp__unblocked__*`,
+	// `mcp__context7__*`, or `Bash(gh ...)` identifiers in the embedded
+	// prompt would push the agent toward tools a fresh-install user does
+	// not have. Claude Code injects the actually-available tools into its
+	// system prompt, so the agent discovers them without `worktask`
+	// naming them.
+	got, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\"): %v", err)
+	}
+	forbidden := []string{
+		"mcp__claude_ai_",
+		"mcp__unblocked__",
+		"mcp__context7__",
+		"Bash(gh",
+	}
+	for _, sub := range forbidden {
+		if strings.Contains(got, sub) {
+			t.Errorf("embedded prompt must not name install-specific identifier %q", sub)
+		}
+	}
+}
+
+func TestEmbeddedDefault_retainsAbstractAnchorGuidance(t *testing.T) {
+	// The prompt should still steer the agent to the right kind of tool
+	// for each anchor type, just abstractly. Loss of this guidance would
+	// degrade research quality in lockstep with the identifier strip.
+	got, err := Load("")
+	if err != nil {
+		t.Fatalf("Load(\"\"): %v", err)
+	}
+	lower := strings.ToLower(got)
+	mustMention := []string{"slack", "jira", "datadog", "library", "gh "}
+	for _, sub := range mustMention {
+		if !strings.Contains(lower, sub) {
+			t.Errorf("embedded prompt missing abstract anchor guidance for %q", sub)
+		}
+	}
+}
+
 func TestRender_substitutesBodyVerbatim(t *testing.T) {
 	tmpl := "Research this task body:\n{{.Body}}\n--end--\n"
 	tk := task.Task{

--- a/internal/research/runner/runner.go
+++ b/internal/research/runner/runner.go
@@ -43,108 +43,24 @@ type Command struct {
 	Stdin string
 }
 
-// allowedTools is the explicit read-only allowlist passed to claude via
-// --allowed-tools. Adding or removing a tool is a code review step, not
-// an emergent behavior. Disallowed by omission: Edit, Write, NotebookEdit,
-// TodoWrite, any MCP write method, all Gmail/HubSpot/Calendar tools.
+// allowedTools is the install-agnostic baseline allowlist passed to claude
+// via --allowed-tools. It contains only built-in read-only tools that every
+// install has — no MCPs, no Bash patterns. The shipped binary cannot assume
+// any particular MCP server is installed in the user's environment, so
+// install-specific tool wiring (Slack/Jira/Datadog MCPs, Bash(gh:*) patterns,
+// etc.) is config-owned: users opt in via worktask config, which a
+// follow-up slice will load with validation that rejects bare Bash and any
+// non-`mcp__*`/non-`Bash(...)` entry.
 //
-// Bash is allowed only under explicit subcommand patterns (e.g.
-// Bash(gh issue view:*)); bare Bash is denied. The argv-pattern check
-// in claude is the safety boundary, so any new Bash entry must be a
-// prefix that no write-capable subcommand can match.
-//
-// MCP tool names must be fully qualified as mcp__<server>__<tool>. The
-// bare-name form is silently denied even with --permission-mode=bypassPermissions.
+// Adding a tool here means it must be safe for every install, with no
+// runtime configuration. The bar is "read-only built-in." Any tool that
+// requires user-side setup belongs in config, not here.
 var allowedTools = []string{
-	// Built-in read-only.
 	"Read",
 	"Glob",
 	"Grep",
 	"WebSearch",
 	"WebFetch",
-
-	// Atlassian MCP, read-only subset.
-	"mcp__claude_ai_Atlassian__getJiraIssue",
-	"mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql",
-	"mcp__claude_ai_Atlassian__getJiraIssueRemoteIssueLinks",
-	"mcp__claude_ai_Atlassian__getConfluencePage",
-	"mcp__claude_ai_Atlassian__searchConfluenceUsingCql",
-	"mcp__claude_ai_Atlassian__getConfluencePageDescendants",
-	"mcp__claude_ai_Atlassian__getConfluencePageFooterComments",
-	"mcp__claude_ai_Atlassian__getConfluencePageInlineComments",
-	"mcp__claude_ai_Atlassian__getConfluenceCommentChildren",
-	"mcp__claude_ai_Atlassian__getPagesInConfluenceSpace",
-	"mcp__claude_ai_Atlassian__getConfluenceSpaces",
-	"mcp__claude_ai_Atlassian__getIssueLinkTypes",
-	"mcp__claude_ai_Atlassian__getJiraProjectIssueTypesMetadata",
-	"mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields",
-	"mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
-	"mcp__claude_ai_Atlassian__getVisibleJiraProjects",
-	"mcp__claude_ai_Atlassian__lookupJiraAccountId",
-	"mcp__claude_ai_Atlassian__atlassianUserInfo",
-	"mcp__claude_ai_Atlassian__getAccessibleAtlassianResources",
-	"mcp__claude_ai_Atlassian__search",
-	"mcp__claude_ai_Atlassian__fetch",
-
-	// Datadog MCP — entirely read-only by design.
-	"mcp__claude_ai_Datadog__aggregate_events",
-	"mcp__claude_ai_Datadog__aggregate_rum_events",
-	"mcp__claude_ai_Datadog__aggregate_spans",
-	"mcp__claude_ai_Datadog__analyze_datadog_logs",
-	"mcp__claude_ai_Datadog__get_datadog_dashboard",
-	"mcp__claude_ai_Datadog__get_datadog_incident",
-	"mcp__claude_ai_Datadog__get_datadog_metric",
-	"mcp__claude_ai_Datadog__get_datadog_metric_context",
-	"mcp__claude_ai_Datadog__get_datadog_notebook",
-	"mcp__claude_ai_Datadog__get_datadog_trace",
-	"mcp__claude_ai_Datadog__search_datadog_dashboards",
-	"mcp__claude_ai_Datadog__search_datadog_events",
-	"mcp__claude_ai_Datadog__search_datadog_hosts",
-	"mcp__claude_ai_Datadog__search_datadog_incidents",
-	"mcp__claude_ai_Datadog__search_datadog_logs",
-	"mcp__claude_ai_Datadog__search_datadog_metrics",
-	"mcp__claude_ai_Datadog__search_datadog_metrics_v2",
-	"mcp__claude_ai_Datadog__search_datadog_monitors",
-	"mcp__claude_ai_Datadog__search_datadog_notebooks",
-	"mcp__claude_ai_Datadog__search_datadog_rum_events",
-	"mcp__claude_ai_Datadog__search_datadog_service_dependencies",
-	"mcp__claude_ai_Datadog__search_datadog_services",
-	"mcp__claude_ai_Datadog__search_datadog_spans",
-
-	// Slack MCP, read-only subset.
-	"mcp__claude_ai_Slack__slack_read_channel",
-	"mcp__claude_ai_Slack__slack_read_thread",
-	"mcp__claude_ai_Slack__slack_read_canvas",
-	"mcp__claude_ai_Slack__slack_read_user_profile",
-	"mcp__claude_ai_Slack__slack_search_channels",
-	"mcp__claude_ai_Slack__slack_search_public",
-	"mcp__claude_ai_Slack__slack_search_public_and_private",
-	"mcp__claude_ai_Slack__slack_search_users",
-
-	// Unblocked MCP — entirely read-only by design.
-	"mcp__unblocked__context_research",
-	"mcp__unblocked__context_get_urls",
-
-	// context7 MCP — library / framework / SDK / CLI documentation
-	// lookups. Read-only by design.
-	"mcp__context7__resolve-library-id",
-	"mcp__context7__query-docs",
-
-	// gh CLI, read-only verbs only. The agent inherits the parent
-	// process's gh auth state. gh's write subcommands (create, edit,
-	// close, merge, comment, delete, review, lock, pin, develop) live
-	// under different verbs, so the prefixes below cannot match them.
-	//
-	// gh api is intentionally NOT on this list. It can issue arbitrary
-	// HTTP methods (gh api -X POST/PATCH/DELETE, or -f field=value which
-	// auto-switches to POST), so the read/write boundary would collapse
-	// to the gh auth token's scopes rather than the argv pattern.
-	"Bash(gh issue view:*)",
-	"Bash(gh issue list:*)",
-	"Bash(gh pr view:*)",
-	"Bash(gh pr list:*)",
-	"Bash(gh pr diff:*)",
-	"Bash(gh search:*)",
 }
 
 // Source cites where an agent claim came from.

--- a/internal/research/runner/runner_test.go
+++ b/internal/research/runner/runner_test.go
@@ -6,6 +6,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
@@ -79,45 +80,32 @@ func TestBuildCommand_defaultModelIsSonnet(t *testing.T) {
 	}
 }
 
-func TestBuildCommand_allowedToolsContainsExplicitReadOnlyList(t *testing.T) {
+func TestBuildCommand_allowedToolsIsExactlyTheVanillaBaseline(t *testing.T) {
+	// The shipped binary's baseline allowlist is the universal,
+	// install-agnostic set of read-only built-ins. User MCPs and Bash(gh:*)
+	// patterns are config-owned (loaded with validation in a follow-up
+	// slice), not in-source.
 	cmd := BuildCommand(RunInput{Prompt: "x"})
 
 	allowed := allowedToolsFlag(cmd.Args)
 	if allowed == "" {
 		t.Fatalf("Args missing --allowed-tools flag; got %v", cmd.Args)
 	}
-	tools := strings.Split(allowed, ",")
-	set := make(map[string]bool, len(tools))
-	for _, name := range tools {
-		set[name] = true
-	}
+	got := strings.Split(allowed, ",")
 
-	mustHave := []string{
-		"Read", "Glob", "Grep", "WebSearch", "WebFetch",
-		"mcp__claude_ai_Atlassian__getJiraIssue",
-		"mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql",
-		"mcp__claude_ai_Slack__slack_read_thread",
-		"mcp__claude_ai_Slack__slack_search_public",
-		"mcp__unblocked__context_research",
-		"mcp__claude_ai_Datadog__search_datadog_logs",
-		"mcp__context7__resolve-library-id",
-		"mcp__context7__query-docs",
-		// gh CLI, pattern-restricted Bash, read-only verbs only.
-		"Bash(gh issue view:*)",
-		"Bash(gh issue list:*)",
-		"Bash(gh pr view:*)",
-		"Bash(gh pr list:*)",
-		"Bash(gh pr diff:*)",
-		"Bash(gh search:*)",
-	}
-	for _, name := range mustHave {
-		if !set[name] {
-			t.Errorf("allowed-tools missing %q; got %v", name, tools)
-		}
+	want := []string{"Read", "Glob", "Grep", "WebSearch", "WebFetch"}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("baseline allowed-tools mismatch:\n got: %v\nwant: %v", got, want)
 	}
 }
 
-func TestBuildCommand_allowedToolsExcludesWriteCapableTools(t *testing.T) {
+func TestBuildCommand_allowedToolsExcludesBuiltInWrites(t *testing.T) {
+	// Safety net against accidental additions to the baseline. The shipped
+	// binary must never grant the agent write-capable built-ins, and must
+	// never grant unrestricted Bash (bare `Bash`) or the wildcard escape
+	// hatch `Bash(*)`. MCP write methods and Bash(gh ...) write verbs are
+	// not enumerated here — they are config-owned and rejected at config
+	// load by the validator in a follow-up slice.
 	cmd := BuildCommand(RunInput{Prompt: "x"})
 
 	allowed := allowedToolsFlag(cmd.Args)
@@ -128,37 +116,16 @@ func TestBuildCommand_allowedToolsExcludesWriteCapableTools(t *testing.T) {
 	}
 
 	mustNotHave := []string{
-		// Unrestricted Bash is denied; only Bash(<pattern>) entries are allowed.
 		"Bash",
-		"Edit", "Write", "NotebookEdit", "TodoWrite",
-		"mcp__claude_ai_Slack__slack_send_message",
-		"mcp__claude_ai_Slack__slack_send_message_draft",
-		"mcp__claude_ai_Slack__slack_create_canvas",
-		"mcp__claude_ai_Atlassian__editJiraIssue",
-		"mcp__claude_ai_Atlassian__createJiraIssue",
-		"mcp__claude_ai_Atlassian__transitionJiraIssue",
-		"mcp__claude_ai_Atlassian__addCommentToJiraIssue",
-		"mcp__claude_ai_Atlassian__updateConfluencePage",
-		"mcp__claude_ai_Atlassian__createConfluencePage",
-		// gh: explicitly forbid the wildcard escape hatch and the
-		// write-capable verbs. gh api can issue arbitrary HTTP methods
-		// (-X POST/PATCH/DELETE), so it is not safe under a glob.
-		"Bash(gh:*)",
-		"Bash(gh api:*)",
-		"Bash(gh issue create:*)",
-		"Bash(gh issue edit:*)",
-		"Bash(gh issue close:*)",
-		"Bash(gh issue comment:*)",
-		"Bash(gh pr create:*)",
-		"Bash(gh pr edit:*)",
-		"Bash(gh pr close:*)",
-		"Bash(gh pr merge:*)",
-		"Bash(gh pr review:*)",
-		"Bash(gh pr comment:*)",
+		"Bash(*)",
+		"Edit",
+		"Write",
+		"NotebookEdit",
+		"TodoWrite",
 	}
 	for _, name := range mustNotHave {
 		if set[name] {
-			t.Errorf("allowed-tools must NOT include write-capable %q", name)
+			t.Errorf("baseline allowed-tools must NOT include write-capable %q", name)
 		}
 	}
 }


### PR DESCRIPTION
## Summary

- Shrinks the in-source `allowedTools` slice in the research runner to exactly the five universal read-only built-ins (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`) and rewrites the security comment to document the new "vanilla baseline + config-owned extensions" split. Install-specific MCPs and `Bash(gh ...)` patterns become config-owned in a follow-up slice (with load-time validation that rejects bare `Bash` and any non-`mcp__*`/non-`Bash(...)` entry).
- Rewrites the embedded research-prompt template to remove every `mcp__claude_ai_*`, `mcp__unblocked__*`, `mcp__context7__*`, and `Bash(gh ...)` identifier from the data-source guidance, replacing them with abstract per-anchor guidance ("prefer any read-only Slack MCP you have access to", etc.). Claude Code injects the actually-available tools into its system prompt, so the agent discovers them without `worktask` naming them. Prompt-loading mechanism and the override path at `$XDG_CONFIG_HOME/worktask/research-prompt.md` are unchanged; no auto-install on first run.
- Refactors the existing baseline-shape test to assert exact-equality on the five-name set, trims the must-not-have test to built-in writes only (`Bash`, `Bash(*)`, `Edit`, `Write`, `NotebookEdit`, `TodoWrite`), and adds two embedded-prompt tests: one forbidding install-specific identifiers, one asserting the abstract anchor guidance still covers Slack, Jira, Datadog, library docs, and `gh`-style PR/issue lookups.

End-to-end behavior: a fresh-install user running `worktask research` sees an allowlist with only the five built-in read-only tools and a prompt that names no MCPs.

Refs: #2

## Test plan

- [x] `go test ./...` is green
- [x] `internal/research/runner` baseline test asserts exact-equality on `[Read, Glob, Grep, WebSearch, WebFetch]`
- [x] `internal/research/runner` must-not-have test catches accidental additions of bare `Bash`, `Bash(*)`, or any built-in write
- [x] `internal/research/prompt` test rejects any reintroduction of `mcp__claude_ai_*`, `mcp__unblocked__*`, `mcp__context7__*`, or `Bash(gh ...)` substrings in the embedded default
- [x] `internal/research/prompt` test confirms abstract anchor guidance still names Slack, Jira, Datadog, library docs, and `gh ` (PR/issue) lookups
- [ ] Follow-up slice: load + validate user-extension allowlist from config (rejects bare `Bash`, requires `mcp__*` or `Bash(...)` shape)

🤖 Generated with [Claude Code](https://claude.com/claude-code)