### PR TITLE
feat(config): add research_extra_tools with load-time validation

### DIFF
--- a/cmd/research.go
+++ b/cmd/research.go
@@ -85,9 +85,10 @@ func runSingleResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, fr
 	}
 
 	result, runErr := runner.Run(context.Background(), runner.RunInput{
-		Prompt:  rendered,
-		LogPath: logPath,
-		Model:   resolveResearchModel(cfg),
+		Prompt:     rendered,
+		LogPath:    logPath,
+		Model:      resolveResearchModel(cfg),
+		ExtraTools: cfg.ResearchExtraTools,
 	}, runner.OSExec{})
 	if runErr != nil {
 		result = runner.Result{
@@ -179,11 +180,13 @@ func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store) err
 	defer cancel()
 
 	model := resolveResearchModel(cfg)
+	extraTools := cfg.ResearchExtraTools
 	runFn := func(ctx context.Context, item pool.Item) (runner.Result, error) {
 		return runner.Run(ctx, runner.RunInput{
-			Prompt:  item.Prompt,
-			LogPath: meta[item.Task.ID].logPath,
-			Model:   model,
+			Prompt:     item.Prompt,
+			LogPath:    meta[item.Task.ID].logPath,
+			Model:      model,
+			ExtraTools: extraTools,
 		}, runner.OSExec{})
 	}
 

--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -65,6 +65,12 @@ curl -fsSL https://raw.githubusercontent.com/jvcorredor/worktask/main/docs/src/c
 The file's frontmatter is Claude-Code-compatible (`description:`, `argument-hint:`); the additional `title:` key Starlight needs is ignored by Claude Code, so the raw download is a drop-in slash command source.
 :::
 
+## Research-agent allowlist
+
+`worktask research` spawns a headless Claude Code subagent under `--permission-mode=bypassPermissions`, with an explicit `--allowed-tools` list. That list is the security boundary, and it is config-driven on a per-machine basis: the shipped binary contributes a vanilla baseline of five built-in read-only tools (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`), and the user's `config.toml` extends it via [`research_extra_tools`](./config.md#research_extra_tools). MCP tool names and pattern-restricted `Bash(...)` invocations belong in the config, not in the binary.
+
+If you are wrapping `worktask research` from another agent, you do not need to thread tool names through the wrapper — they live in the operator's `config.toml`. The CLI surface (subcommand name, flags, JSON output, exit-code envelope) is unchanged by the allowlist mechanism.
+
 ## Skills
 
 Claude Code also exposes a wrapper surface called *skills* alongside slash commands. A `worktask` skill is a viable future direction — no worked example is included here yet because there isn't one to vendor.

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -22,6 +22,7 @@ worktask append <fragment> <text>
 worktask complete <fragment>
 worktask reopen <fragment>
 worktask edit <fragment>
+worktask research [<fragment>]
 ```
 
 `<fragment>` is anything that resolves to a single task. See [Match resolution](#match-resolution) below.
@@ -105,6 +106,27 @@ $ worktask edit milk
 ```
 
 This command is not usable from an agent shell because it replaces the calling process with the editor. The reference slash command instructs the user to run `worktask edit <id>` from their own shell instead.
+
+## `research`
+
+Spawns a headless Claude Code agent to gather context for one task or sweep every open task. The agent runs unattended with `--permission-mode=bypassPermissions`; the security boundary is the `--allowed-tools` list passed to it.
+
+```
+$ worktask research milk        # research a single task
+$ worktask research              # batch-research every open task
+```
+
+Flags:
+
+- `--concurrency N` (default `3`): max concurrent in-flight research runs in batch mode.
+- `--all`: force re-research of every open task, ignoring `last_researched`.
+- `--stale DURATION`: re-research tasks whose `last_researched` is older than this duration.
+- `--timeout DURATION` (default `10m`): per-task hard timeout.
+- `--model ID`: claude model id; overrides `research_model` from `config.toml`.
+
+The shipped binary's `--allowed-tools` baseline contains five built-in read-only tools and nothing else: `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`. To extend the allowlist with MCP tools or pattern-restricted `Bash(...)` invocations on a per-machine basis, add a [`research_extra_tools`](./config.md#research_extra_tools) block to your `config.toml`. There is no `--extra-tool` flag; tool availability is a per-machine property, not a per-invocation one.
+
+JSON output is documented in [Agentic usage](./agentic.md).
 
 ## Match resolution
 

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -1,6 +1,6 @@
 ---
 title: Configuration
-description: Configuring worktask via tasks_dir, editor, XDG paths, and resolution order.
+description: Configuring worktask via tasks_dir, editor, research_model, research_prompt_path, research_extra_tools, XDG paths, and resolution order.
 ---
 
 `worktask` is configured via a single optional TOML file. There is no `init` step: if the file is absent, `worktask` runs on defaults. If it is present, every key in it is optional.
@@ -16,6 +16,13 @@ The file is never created automatically. Drop one in if you want to override a d
 ```toml
 tasks_dir = "/custom/path"
 editor    = "code --wait"
+
+research_model       = "claude-sonnet-4-6"
+research_prompt_path = "/custom/path/to/research-prompt.md"
+research_extra_tools = [
+  "mcp__claude_ai_Slack__slack_read_thread",
+  "Bash(gh pr view:*)",
+]
 ```
 
 ## `tasks_dir`
@@ -33,3 +40,168 @@ Resolution order:
 3. `vi`
 
 The first value that is set wins. `vi` is the final fallback.
+
+## `research_model`
+
+Claude model id used by the headless research agent (`worktask research`).
+
+When unset, the runner picks its built-in default, currently `claude-sonnet-4-6`. Sonnet is the right default for retrieval+summarization across MCP tools — the interactive default (often Opus) would burn the usage limit on every batch sweep without a meaningful quality gain here.
+
+The `--model` flag on `worktask research` overrides this key for a single invocation.
+
+## `research_prompt_path`
+
+Path to a custom research prompt template. When unset, `worktask` ships an embedded default that is used as-is.
+
+The default is `<config_dir>/research-prompt.md` — i.e. a sibling of `config.toml`. Drop a file at that path (or anywhere `research_prompt_path` points) to override the embedded prompt without recompiling the binary.
+
+There is no auto-install of a starter prompt on first run. If the file does not exist, the embedded default is used.
+
+## `research_extra_tools`
+
+A list of allowlist entries appended verbatim to the research agent's `--allowed-tools` argument, after the in-source baseline (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`).
+
+Use this key to give the research agent access to your machine's MCP servers and to pattern-restricted `Bash(...)` invocations. The shipped binary deliberately ships no MCP entries — those are install-specific and live in your `config.toml`.
+
+```toml
+research_extra_tools = [
+  "mcp__claude_ai_Slack__slack_read_thread",
+  "Bash(gh pr view:*)",
+]
+```
+
+When the key is absent, the agent runs against only the vanilla baseline.
+
+### Threat model
+
+The research agent is spawned by `worktask` with `--permission-mode=bypassPermissions`. It runs unattended. The `--allowed-tools` list is the security boundary: anything on it can be invoked without prompting; anything off it is denied.
+
+That makes the contents of `research_extra_tools` security-meaningful. Two rules follow:
+
+1. **Only add read-only entries.** The validator blocks the obvious built-in writes (see [Validation](#validation) below), but it cannot enumerate every write-capable MCP tool — there are infinite MCP server names. Per-MCP safety is your responsibility. If your Slack MCP exposes both `slack_read_thread` and `slack_send_message`, list only the read tool.
+2. **`gh` is allowed only under explicit subcommand patterns.** `Bash(gh:*)` is a glob escape hatch and is not safe — `gh` has many write subcommands (`create`, `edit`, `close`, `merge`, `comment`, `delete`, `review`, `lock`, `pin`, `develop`) and `gh api` issues arbitrary HTTP methods. Pin to specific read verbs: `Bash(gh pr view:*)`, `Bash(gh issue list:*)`.
+
+### Validation
+
+`worktask` rejects entries that would let the unattended agent write to disk or run arbitrary shell commands at config load. The error names the offending entry, its index in the list, and the path of the `config.toml` it came from, so you can locate and fix it in seconds.
+
+Rejected entries:
+
+| Entry | Reason |
+|-------|--------|
+| `Edit` | Built-in write tool. |
+| `Write` | Built-in write tool. |
+| `NotebookEdit` | Built-in write tool. |
+| `TodoWrite` | Built-in write tool. |
+| `Bash` | Bare `Bash` is unrestricted shell access. |
+| `Bash(*)` | Wildcard escape hatch — equivalent to bare `Bash`. |
+| `Bash(*:...)` | Wildcard binary in front of any subcommand — equivalent to bare `Bash`. |
+
+MCP write methods are not enumerated. They are not blocked. Per-MCP safety is your responsibility per the threat model above.
+
+### Starter snippets
+
+Drop one or more of these into your `config.toml` under `research_extra_tools`. Each block is read-only by design. Mix and match to match the MCPs you actually have installed.
+
+#### Atlassian (Jira + Confluence) — read-only
+
+```toml
+research_extra_tools = [
+  "mcp__claude_ai_Atlassian__getJiraIssue",
+  "mcp__claude_ai_Atlassian__searchJiraIssuesUsingJql",
+  "mcp__claude_ai_Atlassian__getJiraIssueRemoteIssueLinks",
+  "mcp__claude_ai_Atlassian__getConfluencePage",
+  "mcp__claude_ai_Atlassian__searchConfluenceUsingCql",
+  "mcp__claude_ai_Atlassian__getConfluencePageDescendants",
+  "mcp__claude_ai_Atlassian__getConfluencePageFooterComments",
+  "mcp__claude_ai_Atlassian__getConfluencePageInlineComments",
+  "mcp__claude_ai_Atlassian__getConfluenceCommentChildren",
+  "mcp__claude_ai_Atlassian__getPagesInConfluenceSpace",
+  "mcp__claude_ai_Atlassian__getConfluenceSpaces",
+  "mcp__claude_ai_Atlassian__getIssueLinkTypes",
+  "mcp__claude_ai_Atlassian__getJiraProjectIssueTypesMetadata",
+  "mcp__claude_ai_Atlassian__getJiraIssueTypeMetaWithFields",
+  "mcp__claude_ai_Atlassian__getTransitionsForJiraIssue",
+  "mcp__claude_ai_Atlassian__getVisibleJiraProjects",
+  "mcp__claude_ai_Atlassian__lookupJiraAccountId",
+  "mcp__claude_ai_Atlassian__atlassianUserInfo",
+  "mcp__claude_ai_Atlassian__getAccessibleAtlassianResources",
+  "mcp__claude_ai_Atlassian__search",
+  "mcp__claude_ai_Atlassian__fetch",
+]
+```
+
+#### Slack — read-only
+
+```toml
+research_extra_tools = [
+  "mcp__claude_ai_Slack__slack_read_channel",
+  "mcp__claude_ai_Slack__slack_read_thread",
+  "mcp__claude_ai_Slack__slack_read_canvas",
+  "mcp__claude_ai_Slack__slack_read_user_profile",
+  "mcp__claude_ai_Slack__slack_search_channels",
+  "mcp__claude_ai_Slack__slack_search_public",
+  "mcp__claude_ai_Slack__slack_search_public_and_private",
+  "mcp__claude_ai_Slack__slack_search_users",
+]
+```
+
+#### Datadog — read-only
+
+```toml
+research_extra_tools = [
+  "mcp__claude_ai_Datadog__aggregate_events",
+  "mcp__claude_ai_Datadog__aggregate_rum_events",
+  "mcp__claude_ai_Datadog__aggregate_spans",
+  "mcp__claude_ai_Datadog__analyze_datadog_logs",
+  "mcp__claude_ai_Datadog__get_datadog_dashboard",
+  "mcp__claude_ai_Datadog__get_datadog_incident",
+  "mcp__claude_ai_Datadog__get_datadog_metric",
+  "mcp__claude_ai_Datadog__get_datadog_metric_context",
+  "mcp__claude_ai_Datadog__get_datadog_notebook",
+  "mcp__claude_ai_Datadog__get_datadog_trace",
+  "mcp__claude_ai_Datadog__search_datadog_dashboards",
+  "mcp__claude_ai_Datadog__search_datadog_events",
+  "mcp__claude_ai_Datadog__search_datadog_hosts",
+  "mcp__claude_ai_Datadog__search_datadog_incidents",
+  "mcp__claude_ai_Datadog__search_datadog_logs",
+  "mcp__claude_ai_Datadog__search_datadog_metrics",
+  "mcp__claude_ai_Datadog__search_datadog_metrics_v2",
+  "mcp__claude_ai_Datadog__search_datadog_monitors",
+  "mcp__claude_ai_Datadog__search_datadog_notebooks",
+  "mcp__claude_ai_Datadog__search_datadog_rum_events",
+  "mcp__claude_ai_Datadog__search_datadog_service_dependencies",
+  "mcp__claude_ai_Datadog__search_datadog_services",
+  "mcp__claude_ai_Datadog__search_datadog_spans",
+]
+```
+
+#### context7 — library / SDK / framework documentation
+
+```toml
+research_extra_tools = [
+  "mcp__context7__resolve-library-id",
+  "mcp__context7__query-docs",
+]
+```
+
+#### `gh` CLI — read-only Bash patterns
+
+```toml
+research_extra_tools = [
+  "Bash(gh issue view:*)",
+  "Bash(gh issue list:*)",
+  "Bash(gh pr view:*)",
+  "Bash(gh pr list:*)",
+  "Bash(gh pr diff:*)",
+  "Bash(gh search:*)",
+]
+```
+
+`gh api` is intentionally not on this list. It can issue arbitrary HTTP methods (`-X POST/PATCH/DELETE`, or `-f field=value` which auto-switches to POST), so the read/write boundary collapses to the `gh` auth token's scopes rather than the argv pattern.
+
+### Migrating from older `worktask`
+
+Earlier versions of `worktask` shipped a personal allowlist hard-coded into the binary — Atlassian, Slack, Datadog, and `gh` MCP tool names were all in-source. That is no longer the case: the shipped binary's allowlist is `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`, and nothing else.
+
+If you were relying on the old in-source allowlist, add a `research_extra_tools` block to your `config.toml` per machine. The starter snippets above are drop-in equivalents to the previously-bundled lists.

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -6,6 +6,7 @@ import (
 	"io/fs"
 	"os"
 	"path/filepath"
+	"strings"
 
 	"github.com/BurntSushi/toml"
 )
@@ -18,14 +19,19 @@ type Config struct {
 	// ResearchModel overrides the model used by the headless research agent.
 	// Empty means the runner picks its DefaultModel.
 	ResearchModel string
+	// ResearchExtraTools is appended verbatim to the research agent's
+	// --allowed-tools baseline. Validated at Load(); a Config that has
+	// escaped this package is known-clean.
+	ResearchExtraTools []string
 }
 
 type fileConfig struct {
-	TasksDir           string `toml:"tasks_dir"`
-	Editor             string `toml:"editor"`
-	ResearchPromptPath string `toml:"research_prompt_path"`
-	WorkingLogPath     string `toml:"working_log_path"`
-	ResearchModel      string `toml:"research_model"`
+	TasksDir           string   `toml:"tasks_dir"`
+	Editor             string   `toml:"editor"`
+	ResearchPromptPath string   `toml:"research_prompt_path"`
+	WorkingLogPath     string   `toml:"working_log_path"`
+	ResearchModel      string   `toml:"research_model"`
+	ResearchExtraTools []string `toml:"research_extra_tools"`
 }
 
 func Load() (Config, error) {
@@ -35,12 +41,17 @@ func Load() (Config, error) {
 		return Config{}, fmt.Errorf("config: read %s: %w", path, err)
 	}
 
+	if err := ValidateExtraTools(fc.ResearchExtraTools, path); err != nil {
+		return Config{}, err
+	}
+
 	cfg := Config{
 		TasksDir:           fc.TasksDir,
 		Editor:             fc.Editor,
 		ResearchPromptPath: fc.ResearchPromptPath,
 		WorkingLogPath:     fc.WorkingLogPath,
 		ResearchModel:      fc.ResearchModel,
+		ResearchExtraTools: fc.ResearchExtraTools,
 	}
 	if cfg.TasksDir == "" {
 		cfg.TasksDir = defaultTasksDir()
@@ -69,6 +80,35 @@ func configFilePath() string {
 		return filepath.Join(dir, "worktask", "config.toml")
 	}
 	return filepath.Join(os.Getenv("HOME"), ".config", "worktask", "config.toml")
+}
+
+// ValidateExtraTools enforces the security policy on user-supplied additions
+// to the research agent's --allowed-tools list. Because the agent runs
+// unattended with --permission-mode=bypassPermissions, the allowlist is the
+// security boundary; entries that would let it write to disk or run arbitrary
+// shell commands must be rejected before a Config escapes Load().
+//
+// configPath is the path of the config.toml the entries came from; it is
+// included in the error so the user can locate the offending value.
+func ValidateExtraTools(extras []string, configPath string) error {
+	bareWriteCapable := map[string]bool{
+		"Edit":         true,
+		"Write":        true,
+		"NotebookEdit": true,
+		"TodoWrite":    true,
+		"Bash":         true,
+	}
+	for i, entry := range extras {
+		if bareWriteCapable[entry] {
+			return fmt.Errorf("config: research_extra_tools[%d] = %q is write-capable and cannot be granted to the unattended research agent (in %s)", i, entry, configPath)
+		}
+		// Bash(*) is the unrestricted-shell escape hatch; Bash(*:...) puts a
+		// wildcard binary in front of any subcommand and is equally unsafe.
+		if entry == "Bash(*)" || strings.HasPrefix(entry, "Bash(*:") {
+			return fmt.Errorf("config: research_extra_tools[%d] = %q permits unrestricted shell execution and cannot be granted to the unattended research agent (in %s)", i, entry, configPath)
+		}
+	}
+	return nil
 }
 
 func defaultTasksDir() string {

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -3,6 +3,8 @@ package config
 import (
 	"os"
 	"path/filepath"
+	"reflect"
+	"strings"
 	"testing"
 )
 
@@ -146,6 +148,181 @@ func TestLoad_researchModelFromConfigFile(t *testing.T) {
 	}
 	if cfg.ResearchModel != "claude-haiku-4-5-20251001" {
 		t.Errorf("ResearchModel = %q; want claude-haiku-4-5-20251001", cfg.ResearchModel)
+	}
+}
+
+func TestLoad_researchExtraToolsDecodesFromConfig(t *testing.T) {
+	home := t.TempDir()
+	xdgConfig := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+	t.Setenv("XDG_DATA_HOME", "")
+
+	configDir := filepath.Join(xdgConfig, "worktask")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	contents := []byte("research_extra_tools = [\"mcp__claude_ai_Slack__slack_read_thread\", \"Bash(gh pr view:*)\"]\n")
+	if err := os.WriteFile(filepath.Join(configDir, "config.toml"), contents, 0o644); err != nil {
+		t.Fatalf("write config: %v", err)
+	}
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	want := []string{"mcp__claude_ai_Slack__slack_read_thread", "Bash(gh pr view:*)"}
+	if !reflect.DeepEqual(cfg.ResearchExtraTools, want) {
+		t.Errorf("ResearchExtraTools = %v; want %v", cfg.ResearchExtraTools, want)
+	}
+}
+
+func TestValidateExtraTools_acceptsLegitimateExtras(t *testing.T) {
+	// Realistic shape: a Slack read MCP plus a pattern-restricted gh Bash entry.
+	// The validator's job is only to block write-capable built-ins and
+	// unrestricted Bash; everything else (per-MCP safety, gh subcommand choice)
+	// is the user's responsibility per the threat model.
+	extras := []string{
+		"mcp__claude_ai_Slack__slack_read_thread",
+		"Bash(gh pr view:*)",
+	}
+	if err := ValidateExtraTools(extras, "/tmp/config.toml"); err != nil {
+		t.Errorf("ValidateExtraTools(%v) = %v; want nil", extras, err)
+	}
+}
+
+func TestValidateExtraTools_rejectsWriteCapableEntries(t *testing.T) {
+	const configPath = "/tmp/worktask/config.toml"
+	cases := []struct {
+		name  string
+		entry string
+	}{
+		{"bareEdit", "Edit"},
+		{"bareWrite", "Write"},
+		{"bareNotebookEdit", "NotebookEdit"},
+		{"bareTodoWrite", "TodoWrite"},
+		{"bareBash", "Bash"},
+		{"bashWildcard", "Bash(*)"},
+		{"bashWildcardWithSubcommand", "Bash(*:something)"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := ValidateExtraTools([]string{tc.entry}, configPath)
+			if err == nil {
+				t.Fatalf("ValidateExtraTools(%q) = nil; want error", tc.entry)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tc.entry) {
+				t.Errorf("error %q does not mention offending entry %q", msg, tc.entry)
+			}
+			if !strings.Contains(msg, "0") {
+				t.Errorf("error %q does not mention the entry's index 0", msg)
+			}
+			if !strings.Contains(msg, configPath) {
+				t.Errorf("error %q does not mention config path %q", msg, configPath)
+			}
+		})
+	}
+}
+
+func TestValidateExtraTools_errorMentionsActualOffendingIndex(t *testing.T) {
+	// The bad entry is third (index 2). The message must point at index 2,
+	// not 0, so the user can locate it without scanning.
+	extras := []string{
+		"mcp__claude_ai_Slack__slack_read_thread",
+		"Bash(gh pr view:*)",
+		"Edit",
+	}
+	err := ValidateExtraTools(extras, "/tmp/config.toml")
+	if err == nil {
+		t.Fatalf("ValidateExtraTools = nil; want error")
+	}
+	if !strings.Contains(err.Error(), "[2]") {
+		t.Errorf("error %q does not mention offending index 2", err.Error())
+	}
+}
+
+func TestValidateExtraTools_acceptsNilAndEmpty(t *testing.T) {
+	if err := ValidateExtraTools(nil, "/tmp/config.toml"); err != nil {
+		t.Errorf("ValidateExtraTools(nil) = %v; want nil", err)
+	}
+	if err := ValidateExtraTools([]string{}, "/tmp/config.toml"); err != nil {
+		t.Errorf("ValidateExtraTools([]) = %v; want nil", err)
+	}
+}
+
+func TestLoad_rejectsWriteCapableEntriesInExtraTools(t *testing.T) {
+	// Each row writes a config.toml that contains the bad entry, then asserts
+	// Load() returns an error that names the entry, its index, and the
+	// config.toml path. The validator runs at the system boundary so a Config
+	// with a write-capable extra never escapes the package.
+	const goodEntry = "mcp__claude_ai_Slack__slack_read_thread"
+	cases := []struct {
+		name     string
+		extras   []string
+		bad      string
+		wantIdx  string // bracketed form expected in the error message
+	}{
+		{"bareEdit", []string{"Edit"}, "Edit", "[0]"},
+		{"bareWrite", []string{goodEntry, "Write"}, "Write", "[1]"},
+		{"bareNotebookEdit", []string{"NotebookEdit"}, "NotebookEdit", "[0]"},
+		{"bareTodoWrite", []string{"TodoWrite"}, "TodoWrite", "[0]"},
+		{"bareBash", []string{"Bash"}, "Bash", "[0]"},
+		{"bashWildcard", []string{goodEntry, goodEntry, "Bash(*)"}, "Bash(*)", "[2]"},
+		{"bashWildcardWithSubcommand", []string{"Bash(*:rm -rf /)"}, "Bash(*:rm -rf /)", "[0]"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			home := t.TempDir()
+			xdgConfig := t.TempDir()
+			t.Setenv("HOME", home)
+			t.Setenv("XDG_CONFIG_HOME", xdgConfig)
+			t.Setenv("XDG_DATA_HOME", "")
+
+			configDir := filepath.Join(xdgConfig, "worktask")
+			if err := os.MkdirAll(configDir, 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			quoted := make([]string, len(tc.extras))
+			for i, e := range tc.extras {
+				quoted[i] = `"` + e + `"`
+			}
+			contents := []byte("research_extra_tools = [" + strings.Join(quoted, ", ") + "]\n")
+			configPath := filepath.Join(configDir, "config.toml")
+			if err := os.WriteFile(configPath, contents, 0o644); err != nil {
+				t.Fatalf("write config: %v", err)
+			}
+
+			_, err := Load()
+			if err == nil {
+				t.Fatalf("Load() = nil error; want one rejecting %q", tc.bad)
+			}
+			msg := err.Error()
+			if !strings.Contains(msg, tc.bad) {
+				t.Errorf("error %q does not mention offending entry %q", msg, tc.bad)
+			}
+			if !strings.Contains(msg, tc.wantIdx) {
+				t.Errorf("error %q does not mention index %s", msg, tc.wantIdx)
+			}
+			if !strings.Contains(msg, configPath) {
+				t.Errorf("error %q does not mention config path %q", msg, configPath)
+			}
+		})
+	}
+}
+
+func TestLoad_researchExtraToolsAbsentYieldsNil(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_DATA_HOME", "")
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	cfg, err := Load()
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if cfg.ResearchExtraTools != nil {
+		t.Errorf("ResearchExtraTools = %v; want nil when key is absent", cfg.ResearchExtraTools)
 	}
 }
 

--- a/internal/research/runner/runner.go
+++ b/internal/research/runner/runner.go
@@ -32,6 +32,11 @@ type RunInput struct {
 	// Model overrides the model the headless agent runs as. Empty means
 	// DefaultModel.
 	Model string
+	// ExtraTools is appended verbatim to the baseline allowlist in the
+	// --allowed-tools argument. Validation is the caller's responsibility:
+	// by the time a RunInput exists, ExtraTools is known-clean (the config
+	// package's ValidateExtraTools has rejected anything write-capable).
+	ExtraTools []string
 }
 
 // Command is a description of the child process to spawn. It is returned
@@ -236,6 +241,8 @@ func BuildCommand(in RunInput) Command {
 	if model == "" {
 		model = DefaultModel
 	}
+	tools := append([]string(nil), allowedTools...)
+	tools = append(tools, in.ExtraTools...)
 	return Command{
 		Bin: "claude",
 		Args: []string{
@@ -245,7 +252,7 @@ func BuildCommand(in RunInput) Command {
 			"--verbose",
 			"--permission-mode=bypassPermissions",
 			"--model=" + model,
-			"--allowed-tools=" + strings.Join(allowedTools, ","),
+			"--allowed-tools=" + strings.Join(tools, ","),
 		},
 		Stdin: in.Prompt,
 	}

--- a/internal/research/runner/runner_test.go
+++ b/internal/research/runner/runner_test.go
@@ -99,6 +99,42 @@ func TestBuildCommand_allowedToolsIsExactlyTheVanillaBaseline(t *testing.T) {
 	}
 }
 
+func TestBuildCommand_allowedToolsAppendsExtraToolsAfterBaseline(t *testing.T) {
+	// User extras are config-owned and threaded through RunInput.ExtraTools.
+	// They are appended to the in-source baseline verbatim (no
+	// transformations, no deduplication) so the user gets exactly what they
+	// wrote. Validation has already happened at config load.
+	cmd := BuildCommand(RunInput{
+		Prompt: "x",
+		ExtraTools: []string{
+			"mcp__claude_ai_Slack__slack_read_thread",
+			"Bash(gh pr view:*)",
+		},
+	})
+
+	got := allowedToolsFlag(cmd.Args)
+	if got == "" {
+		t.Fatalf("Args missing --allowed-tools flag; got %v", cmd.Args)
+	}
+	want := "Read,Glob,Grep,WebSearch,WebFetch,mcp__claude_ai_Slack__slack_read_thread,Bash(gh pr view:*)"
+	if got != want {
+		t.Errorf("--allowed-tools mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
+func TestBuildCommand_extraToolsNilLeavesBaselineUnchanged(t *testing.T) {
+	// A nil ExtraTools must produce exactly the vanilla baseline; an unset
+	// field (the fresh-install case with no config.toml) must not alter the
+	// shipped allowlist.
+	cmd := BuildCommand(RunInput{Prompt: "x"})
+
+	got := allowedToolsFlag(cmd.Args)
+	want := "Read,Glob,Grep,WebSearch,WebFetch"
+	if got != want {
+		t.Errorf("--allowed-tools mismatch:\n got: %s\nwant: %s", got, want)
+	}
+}
+
 func TestBuildCommand_allowedToolsExcludesBuiltInWrites(t *testing.T) {
 	// Safety net against accidental additions to the baseline. The shipped
 	// binary must never grant the agent write-capable built-ins, and must


### PR DESCRIPTION
## Summary

- Adds `Config.ResearchExtraTools []string` and decodes the `research_extra_tools` TOML key into it; `Config.Load()` runs a pure validator at the system boundary so a Config with dirty extras never escapes the package.
- Validator rejects bare `Edit`, `Write`, `NotebookEdit`, `TodoWrite`, `Bash`, plus `Bash(*)` and any entry beginning with `Bash(*:`. Errors name the offending entry, its index, and the `config.toml` path. MCP write methods are not enumerated — per-MCP safety is the user's responsibility, per the threat model.
- `runner.RunInput.ExtraTools` threads through to `BuildCommand`, which appends the extras verbatim to the baseline in `--allowed-tools=...` (no dedup, no transformations). Single-task and batch research paths in `cmd/research.go` both pass `cfg.ResearchExtraTools` through. No new CLI flag.
- Docs (same PR per CLAUDE.md): config page gains `research_extra_tools` (threat model, validation rules, Atlassian/Slack/Datadog/context7/`gh` starter snippets, migration note) and is brought up to date with `research_model` and `research_prompt_path`. CLI page documents `worktask research` and links the baseline to the config key. Agentic-usage page notes the allowlist is config-driven.
- `worktask research`'s CLI surface, JSON output, and exit-code envelope are unchanged.

Refs: #3
Closes: #3

## Test plan

- [x] \`go test ./...\` green
- [x] Table-driven validator test covers Edit/Write/NotebookEdit/TodoWrite/Bash/Bash(*)/Bash(*:...) at the \`Load()\` boundary, asserting each error mentions the entry, index, and config path
- [x] BuildCommand test asserts \`--allowed-tools\` is exactly \`Read,Glob,Grep,WebSearch,WebFetch,<extras>\` when ExtraTools is set, and exactly the baseline when it is nil
- [x] TestValidateExtraTools_acceptsLegitimateExtras covers a realistic Slack-read MCP + \`Bash(gh pr view:*)\` accept case
- [x] Smoke-tested binary against a config with a bad entry — error names the entry, index, and config.toml path

🤖 Generated with [Claude Code](https://claude.com/claude-code)