### PR TITLE
docs: add MIT license and README badges

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Jack Hall
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,5 +1,10 @@
 # worktask
 
+[![Go Reference](https://pkg.go.dev/badge/github.com/jvcorredor/worktask.svg)](https://pkg.go.dev/github.com/jvcorredor/worktask)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jvcorredor/worktask)](https://goreportcard.com/report/github.com/jvcorredor/worktask)
+[![Docs](https://img.shields.io/badge/docs-jvcorredor.github.io%2Fworktask-blue)](https://jvcorredor.github.io/worktask/)
+[![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
+
 A Go CLI for task management designed primarily for LLM-agent consumption (Claude Code), usable as a normal terminal CLI.
 
 ## Install


### PR DESCRIPTION
## Summary
- Add `LICENSE` (MIT, © 2026 Jack Hall).
- Add four badges to `README.md`: Go Reference, Go Report Card, docs site, License.

## Test plan
- [ ] Confirm the four badges render on the GitHub PR / file view.
- [ ] Confirm the License badge links to `LICENSE` in-repo.
- [ ] Confirm Go Report Card and pkg.go.dev resolve for `github.com/jvcorredor/worktask` (Go Report Card may take one cache cycle to populate on first hit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)