### PR TITLE
chore(agents): scaffold per-repo skill config

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -5,7 +5,12 @@ on:
     branches:
       - main
     paths:
-      - docs/**
+      - docs/src/**
+      - docs/astro.config.mjs
+      - docs/package.json
+      - docs/yarn.lock
+      - docs/.yarnrc.yml
+      - docs/.yarn/**
       - .github/workflows/docs.yml
 
 concurrency:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -9,3 +9,17 @@ The docs site at <https://jvcorredor.github.io/worktask/> is the canonical sourc
 Any PR that changes user-visible CLI surface — subcommands, flags, JSON schema, file format, or config keys — must update the corresponding docs page in the same PR. Same-PR is the rule because it is the only thing keeping the docs site from drifting out of sync with the CLI; there is no auto-generated content and no link-checking in CI.
 
 The vendored reference slash command at `docs/src/content/docs/examples/worktask-slash-command.md` is part of that contract. If a JSON schema or error-envelope change requires updating how an agent wraps the CLI, the slash-command file is updated in the same PR as the schema change.
+
+## Agent skills
+
+### Issue tracker
+
+GitHub Issues at `jvcorredor/worktask`, accessed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+
+### Triage labels
+
+Five canonical roles using their default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`). See `docs/agents/triage-labels.md`.
+
+### Domain docs
+
+Single-context: `CONTEXT.md` and `docs/adr/` at the repo root. See `docs/agents/domain.md`.

--- a/docs/agents/domain.md
+++ b/docs/agents/domain.md
@@ -1,0 +1,51 @@
+# Domain Docs
+
+How the engineering skills should consume this repo's domain documentation when exploring the codebase.
+
+## Before exploring, read these
+
+- **`CONTEXT.md`** at the repo root, or
+- **`CONTEXT-MAP.md`** at the repo root if it exists — it points at one `CONTEXT.md` per context. Read each one relevant to the topic.
+- **`docs/adr/`** — read ADRs that touch the area you're about to work in. In multi-context repos, also check `src/<context>/docs/adr/` for context-scoped decisions.
+
+If any of these files don't exist, **proceed silently**. Don't flag their absence; don't suggest creating them upfront. The producer skill (`/grill-with-docs`) creates them lazily when terms or decisions actually get resolved.
+
+## File structure
+
+Single-context repo (most repos):
+
+```
+/
+├── CONTEXT.md
+├── docs/adr/
+│   ├── 0001-event-sourced-orders.md
+│   └── 0002-postgres-for-write-model.md
+└── src/
+```
+
+Multi-context repo (presence of `CONTEXT-MAP.md` at the root):
+
+```
+/
+├── CONTEXT-MAP.md
+├── docs/adr/                          ← system-wide decisions
+└── src/
+    ├── ordering/
+    │   ├── CONTEXT.md
+    │   └── docs/adr/                  ← context-specific decisions
+    └── billing/
+        ├── CONTEXT.md
+        └── docs/adr/
+```
+
+## Use the glossary's vocabulary
+
+When your output names a domain concept (in an issue title, a refactor proposal, a hypothesis, a test name), use the term as defined in `CONTEXT.md`. Don't drift to synonyms the glossary explicitly avoids.
+
+If the concept you need isn't in the glossary yet, that's a signal — either you're inventing language the project doesn't use (reconsider) or there's a real gap (note it for `/grill-with-docs`).
+
+## Flag ADR conflicts
+
+If your output contradicts an existing ADR, surface it explicitly rather than silently overriding:
+
+> _Contradicts ADR-0007 (event-sourced orders) — but worth reopening because…_

--- a/docs/agents/issue-tracker.md
+++ b/docs/agents/issue-tracker.md
@@ -1,0 +1,22 @@
+# Issue tracker: GitHub
+
+Issues and PRDs for this repo live as GitHub issues. Use the `gh` CLI for all operations.
+
+## Conventions
+
+- **Create an issue**: `gh issue create --title "..." --body "..."`. Use a heredoc for multi-line bodies.
+- **Read an issue**: `gh issue view <number> --comments`, filtering comments by `jq` and also fetching labels.
+- **List issues**: `gh issue list --state open --json number,title,body,labels,comments --jq '[.[] | {number, title, body, labels: [.labels[].name], comments: [.comments[].body]}]'` with appropriate `--label` and `--state` filters.
+- **Comment on an issue**: `gh issue comment <number> --body "..."`
+- **Apply / remove labels**: `gh issue edit <number> --add-label "..."` / `--remove-label "..."`
+- **Close**: `gh issue close <number> --comment "..."`
+
+Infer the repo from `git remote -v` — `gh` does this automatically when run inside a clone.
+
+## When a skill says "publish to the issue tracker"
+
+Create a GitHub issue.
+
+## When a skill says "fetch the relevant ticket"
+
+Run `gh issue view <number> --comments`.

--- a/docs/agents/triage-labels.md
+++ b/docs/agents/triage-labels.md
@@ -1,0 +1,15 @@
+# Triage Labels
+
+The skills speak in terms of five canonical triage roles. This file maps those roles to the actual label strings used in this repo's issue tracker.
+
+| Label in mattpocock/skills | Label in our tracker | Meaning                                  |
+| -------------------------- | -------------------- | ---------------------------------------- |
+| `needs-triage`             | `needs-triage`       | Maintainer needs to evaluate this issue  |
+| `needs-info`               | `needs-info`         | Waiting on reporter for more information |
+| `ready-for-agent`          | `ready-for-agent`    | Fully specified, ready for an AFK agent  |
+| `ready-for-human`          | `ready-for-human`    | Requires human implementation            |
+| `wontfix`                  | `wontfix`            | Will not be actioned                     |
+
+When a skill mentions a role (e.g. "apply the AFK-ready triage label"), use the corresponding label string from this table.
+
+Edit the right-hand column to match whatever vocabulary you actually use.


### PR DESCRIPTION
## Summary

- Adds the per-repo configuration that engineering skills (`to-issues`, `triage`, `to-prd`, `qa`, `improve-codebase-architecture`, `diagnose`, `tdd`, `grill-with-docs`) read to know which issue tracker, label vocabulary, and domain-doc layout to use.
- Appends an `## Agent skills` block to `CLAUDE.md` pointing at three new docs under `docs/agents/`:
  - `issue-tracker.md` — GitHub Issues / `gh` CLI conventions, matching the existing `jvcorredor/worktask` remote.
  - `triage-labels.md` — five canonical roles using default label strings (`needs-triage`, `needs-info`, `ready-for-agent`, `ready-for-human`, `wontfix`); corresponding GitHub labels were created in the repo out-of-band.
  - `domain.md` — single-context layout (`CONTEXT.md` + `docs/adr/` at repo root); neither file exists yet, but skills will read them lazily once they do.
- Tightens `.github/workflows/docs.yml` path filter from `docs/**` to the specific paths the Astro/Starlight build actually consumes, so edits under `docs/agents/**` (and any future repo metadata co-located with the docs site) no longer trigger unnecessary rebuilds.

## Test plan

- [ ] CI: confirm the docs workflow does **not** run on this PR (since no files matching the new filter changed). If it does run, the filter is wrong.
- [ ] Sanity-check: edit any file under `docs/src/content/docs/` in a follow-up commit and confirm the docs workflow still fires.
- [ ] Verify rendered `CLAUDE.md` reads cleanly — the new `## Agent skills` block sits below the existing `## Documentation` section.
- [ ] Spot-check the five triage labels exist in the repo: `gh label list --repo jvcorredor/worktask`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)