### PR TITLE
ci(go): add vet and test workflow

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -1,0 +1,28 @@
+name: Go
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+
+jobs:
+  vet-and-test:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          cache: true
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Test
+        run: go test ./...


### PR DESCRIPTION
## Summary

- Adds `.github/workflows/go.yml` running `go vet ./...` and `go test ./...` on push to `main` and on every pull request.
- First tracer bullet of the static-analysis baseline (#7); no linter yet — that lands in a later issue alongside the doc-comment backfill.
- Matches `docs.yml` conventions: pinned action tags (`actions/checkout@v4`, `actions/setup-go@v5`), pinned `go-version: '1.26.x'`, explicit `permissions: contents: read`, no path filters.

Closes #9. Refs #7.

## Test plan

- [x] `go vet ./...` passes locally on this branch.
- [x] `go test ./...` passes locally on this branch.
- [ ] First CI run on this PR is green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)