### PR TITLE
ci(lint): wire golangci-lint into CI with conservative starter set

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -24,5 +24,10 @@ jobs:
       - name: Vet
         run: go vet ./...
 
+      - name: Lint
+        uses: golangci/golangci-lint-action@v9
+        with:
+          version: v2.11.4
+
       - name: Test
         run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,36 @@
+version: "2"
+
+linters:
+  default: none
+  enable:
+    - errcheck
+    - govet
+    - ineffassign
+    - revive
+    - staticcheck
+    - unused
+  settings:
+    staticcheck:
+      # Excluded rules:
+      # - ST1000: package doc comment. The doc-comment backfill lands in a
+      #   follow-up slice; enabling ST1000 here would make CI yellow-by-design.
+      checks:
+        - all
+        - -ST1000
+    revive:
+      # `exported` is revive's load-bearing rule for this repo: it enforces
+      # doc comments on exported identifiers. It is disabled here because the
+      # doc-comment backfill lands in a follow-up slice; turning it on now
+      # would make CI yellow-by-design. The follow-up slice flips this to
+      # `disabled: false` together with the backfill.
+      #
+      # In golangci-lint v2, listing any rule under revive overrides the
+      # default ruleset, so revive currently runs no checks. That is
+      # intentional for this slice.
+      rules:
+        - name: exported
+          disabled: true
+
+formatters:
+  enable:
+    - gofmt

--- a/cmd/add.go
+++ b/cmd/add.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -19,7 +17,7 @@ var addCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "added %s\n", t.ID)
+		cmd.Printf("added %s\n", t.ID)
 		return nil
 	},
 }

--- a/cmd/append.go
+++ b/cmd/append.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +18,7 @@ var appendCmd = &cobra.Command{
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "appended to %s\n", t.ID)
+		cmd.Printf("appended to %s\n", t.ID)
 		return nil
 	},
 }

--- a/cmd/complete.go
+++ b/cmd/complete.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +18,7 @@ var completeCmd = &cobra.Command{
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "completed %s\n", t.ID)
+		cmd.Printf("completed %s\n", t.ID)
 		return nil
 	},
 }

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -38,7 +38,7 @@ var editCmd = &cobra.Command{
 			return fmt.Errorf("edit: locate editor %q: %w", fields[0], err)
 		}
 		argv := append(fields, path)
-		fmt.Fprintf(cmd.ErrOrStderr(), "launching %s %s\n", editor, path)
+		cmd.PrintErrf("launching %s %s\n", editor, path)
 		return syscall.Exec(bin, argv, os.Environ())
 	},
 }

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +18,7 @@ var reopenCmd = &cobra.Command{
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "reopened %s\n", t.ID)
+		cmd.Printf("reopened %s\n", t.ID)
 		return nil
 	},
 }

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -61,7 +61,7 @@ func handleResolveError(cmd *cobra.Command, s *store.Store, fragment string, err
 				return werr
 			}
 		} else {
-			fmt.Fprintf(cmd.ErrOrStderr(), "ambiguous fragment %q. matches:\n", fragment)
+			cmd.PrintErrf("ambiguous fragment %q. matches:\n", fragment)
 			if rerr := render.HumanCandidates(cmd.ErrOrStderr(), amb.Candidates); rerr != nil {
 				return rerr
 			}
@@ -81,7 +81,7 @@ func handleResolveError(cmd *cobra.Command, s *store.Store, fragment string, err
 				return werr
 			}
 		} else {
-			fmt.Fprintf(cmd.ErrOrStderr(), "no match for %q. open tasks:\n", fragment)
+			cmd.PrintErrf("no match for %q. open tasks:\n", fragment)
 			if rerr := render.HumanList(cmd.ErrOrStderr(), openTasks); rerr != nil {
 				return rerr
 			}

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -1,8 +1,6 @@
 package cmd
 
 import (
-	"fmt"
-
 	"github.com/spf13/cobra"
 )
 
@@ -20,7 +18,7 @@ var updateCmd = &cobra.Command{
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
-		fmt.Fprintf(cmd.OutOrStdout(), "updated %s\n", t.ID)
+		cmd.Printf("updated %s\n", t.ID)
 		return nil
 	},
 }

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -45,14 +45,7 @@ func Load() (Config, error) {
 		return Config{}, err
 	}
 
-	cfg := Config{
-		TasksDir:           fc.TasksDir,
-		Editor:             fc.Editor,
-		ResearchPromptPath: fc.ResearchPromptPath,
-		WorkingLogPath:     fc.WorkingLogPath,
-		ResearchModel:      fc.ResearchModel,
-		ResearchExtraTools: fc.ResearchExtraTools,
-	}
+	cfg := Config(fc)
 	if cfg.TasksDir == "" {
 		cfg.TasksDir = defaultTasksDir()
 	}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -258,10 +258,10 @@ func TestLoad_rejectsWriteCapableEntriesInExtraTools(t *testing.T) {
 	// with a write-capable extra never escapes the package.
 	const goodEntry = "mcp__claude_ai_Slack__slack_read_thread"
 	cases := []struct {
-		name     string
-		extras   []string
-		bad      string
-		wantIdx  string // bracketed form expected in the error message
+		name    string
+		extras  []string
+		bad     string
+		wantIdx string // bracketed form expected in the error message
 	}{
 		{"bareEdit", []string{"Edit"}, "Edit", "[0]"},
 		{"bareWrite", []string{goodEntry, "Write"}, "Write", "[1]"},

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -105,14 +105,7 @@ type jsonResearchRun struct {
 }
 
 func JSONResearchRun(r ResearchRun) ([]byte, error) {
-	return marshalIndent(jsonResearchRun{
-		ID:          r.ID,
-		Description: r.Description,
-		Status:      r.Status,
-		Summary:     r.Summary,
-		LogPath:     r.LogPath,
-		Error:       r.Error,
-	})
+	return marshalIndent(jsonResearchRun(r))
 }
 
 // ResearchEvent is one streaming progress event emitted as a single JSON
@@ -209,15 +202,7 @@ type jsonResearchSummaryTotals struct {
 func JSONResearchSummary(s ResearchSummary) ([]byte, error) {
 	results := make([]jsonResearchSummaryResult, 0, len(s.Results))
 	for _, r := range s.Results {
-		results = append(results, jsonResearchSummaryResult{
-			ID:          r.ID,
-			Description: r.Description,
-			Status:      r.Status,
-			Summary:     r.Summary,
-			LogPath:     r.LogPath,
-			Tokens:      r.Tokens,
-			Error:       r.Error,
-		})
+		results = append(results, jsonResearchSummaryResult(r))
 	}
 	return marshalIndent(jsonResearchSummary{
 		BatchID:  s.BatchID,

--- a/internal/research/runner/runner.go
+++ b/internal/research/runner/runner.go
@@ -131,7 +131,7 @@ func Run(ctx context.Context, in RunInput, exec Exec) (Result, error) {
 	if err != nil {
 		return Result{}, fmt.Errorf("runner: create log: %w", err)
 	}
-	defer logFile.Close()
+	defer func() { _ = logFile.Close() }()
 
 	stdout, err := exec.Run(ctx, cmd)
 	if err != nil {

--- a/internal/research/writeback/writeback.go
+++ b/internal/research/writeback/writeback.go
@@ -62,7 +62,7 @@ func appendWorklog(path string, when time.Time, summary string) error {
 	if err != nil {
 		return err
 	}
-	defer f.Close()
+	defer func() { _ = f.Close() }()
 	_, err = f.WriteString(line)
 	return err
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -39,11 +39,11 @@ func TestRoundTrip_researchFieldsSet(t *testing.T) {
 	created := time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC)
 	lastResearched := time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)
 	original := Task{
-		ID:               "abcdef12",
-		Created:          created,
-		LastResearched:   lastResearched,
-		LastResearchLog:  "research-logs/abcdef12_2026-05-01T14-00.jsonl",
-		Body:             "buy milk\n",
+		ID:              "abcdef12",
+		Created:         created,
+		LastResearched:  lastResearched,
+		LastResearchLog: "research-logs/abcdef12_2026-05-01T14-00.jsonl",
+		Body:            "buy milk\n",
 	}
 	data, err := Encode(original)
 	if err != nil {


### PR DESCRIPTION
## Summary

- Adds `.golangci.yml` (v2) at repo root with the conservative starter set: `errcheck`, `govet`, `ineffassign`, `revive`, `staticcheck`, `unused`, plus `gofmt` as a formatter. `revive`'s `exported` rule and `staticcheck`'s `ST1000` are explicitly disabled — doc-comment enforcement lands together with the doc-comment backfill in the follow-up slice so CI is never yellow-by-design.
- Adds a `Lint` step to `.github/workflows/go.yml` between `Vet` and `Test`, using `golangci/golangci-lint-action@v9` with `version: v2.11.4` (pinned, matching the pinned-version style of `docs.yml`).
- Fixes existing violations from the enabled linters in the same change so the gate is green on first run: cobra commands switched to `cmd.Printf`/`cmd.PrintErrf`; deferred file Closes wrapped in `func() { _ = f.Close() }()`; three staticcheck S1016 struct literals converted to type conversions; two test files re-gofmt'd.

User-visible CLI surface (subcommands, flags, JSON schema, file format, config keys) is unchanged.

Closes #10.

## Test plan

- [ ] CI on this PR is green on first run (vet, lint, test all pass).
- [ ] Locally with the pinned binary: `go install github.com/golangci/golangci-lint/v2/cmd/golangci-lint@v2.11.4 && golangci-lint run ./...` reports `0 issues`.
- [ ] `go test ./...` still passes (no behaviour change from the cobra `cmd.Printf` switch or the deferred-Close wrappers).
- [ ] Sanity-check that revive is wired but quiet by design — flipping `exported: disabled: false` in the follow-up slice should start surfacing missing doc comments.

🤖 Generated with [Claude Code](https://claude.com/claude-code)