### PR TITLE
docs(go): backfill exported-symbol doc comments and enforce them

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -10,26 +10,15 @@ linters:
     - staticcheck
     - unused
   settings:
-    staticcheck:
-      # Excluded rules:
-      # - ST1000: package doc comment. The doc-comment backfill lands in a
-      #   follow-up slice; enabling ST1000 here would make CI yellow-by-design.
-      checks:
-        - all
-        - -ST1000
     revive:
       # `exported` is revive's load-bearing rule for this repo: it enforces
-      # doc comments on exported identifiers. It is disabled here because the
-      # doc-comment backfill lands in a follow-up slice; turning it on now
-      # would make CI yellow-by-design. The follow-up slice flips this to
-      # `disabled: false` together with the backfill.
+      # doc comments on exported identifiers.
       #
       # In golangci-lint v2, listing any rule under revive overrides the
-      # default ruleset, so revive currently runs no checks. That is
-      # intentional for this slice.
+      # default ruleset, so only the rules listed here run.
       rules:
         - name: exported
-          disabled: true
+          disabled: false
 
 formatters:
   enable:

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ Any PR that changes user-visible CLI surface — subcommands, flags, JSON schema
 
 The vendored reference slash command at `docs/src/content/docs/examples/worktask-slash-command.md` is part of that contract. If a JSON schema or error-envelope change requires updating how an agent wraps the CLI, the slash-command file is updated in the same PR as the schema change.
 
+## Go source-level docs
+
+Exported Go symbols carry doc comments in the standard Go convention: a complete sentence that begins with the identifier name. Every package has a package doc comment that explains what it does and any contracts (on-disk format, stable schema, side effects).
+
+`go doc <pkg>` is the preferred way to get a package overview — it reads the package and symbol comments straight from source, so it stays current as the code changes.
+
+`golangci-lint run` enforces this via `revive`'s `exported` rule and `staticcheck`'s `ST1000`. Run it before opening a PR; CI runs the same gate. This rule is about internal-developer docs; user-visible CLI surface continues to live on the docs site per the rule above.
+
 ## Agent skills
 
 ### Issue tracker

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,3 +1,19 @@
+// Package cmd assembles the worktask cobra command tree.
+//
+// The root command lives in this file as rootCmd; each subcommand —
+// add, list, show, complete, reopen, edit, update, append,
+// research, research-log — is defined in its own file in this package
+// and attached to rootCmd from that file's init(). Per-command flags,
+// help strings (Cobra's Short and Long), and Run functions are kept
+// next to the command they configure rather than centralised here, so
+// the command tree is built up by package initialisation rather than by
+// an explicit registry.
+//
+// The package's only public entry point is [Execute], which main.go
+// calls. Subcommand var blocks and init functions are intentionally
+// undocumented at the symbol level: per-var doc comments on cobra
+// command values are not idiomatic, and the user-facing help text
+// already lives in each command's Short and Long fields.
 package cmd
 
 import (
@@ -31,6 +47,11 @@ func init() {
 
 var errExit = errors.New("exit")
 
+// Execute runs the worktask CLI: it dispatches the root cobra command,
+// prints any error to stderr (suppressing the sentinel used to short-
+// circuit a subcommand without an extra error line), and exits the
+// process with status 1 on failure. It is the only entry point main.go
+// calls and does not return on error.
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		if !errors.Is(err, errExit) {

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,3 +1,15 @@
+// Package config loads and validates the user's worktask configuration.
+//
+// The configuration is read from a single TOML file. The path is
+// $XDG_CONFIG_HOME/worktask/config.toml when XDG_CONFIG_HOME is set, and
+// $HOME/.config/worktask/config.toml otherwise. A missing file is not an
+// error; defaults fill in. See the user-visible config keys and their
+// meanings on the docs site at
+// <https://jvcorredor.github.io/worktask/configuration/>.
+//
+// [Load] is the only entry point for callers; values that escape this
+// package have already passed [ValidateExtraTools] and are safe to feed
+// into the unattended research agent.
 package config
 
 import (
@@ -11,6 +23,8 @@ import (
 	"github.com/BurntSushi/toml"
 )
 
+// Config is the resolved, validated configuration handed to the rest of
+// the CLI. Defaults for unset fields are applied during [Load].
 type Config struct {
 	TasksDir           string
 	Editor             string
@@ -34,6 +48,11 @@ type fileConfig struct {
 	ResearchExtraTools []string `toml:"research_extra_tools"`
 }
 
+// Load reads and validates the user's config file, returning a Config
+// with defaults applied for any unset fields. A missing config file is
+// not an error and yields a fully-defaulted Config. Validation failures
+// (for example, a write-capable entry in research_extra_tools) are
+// returned as errors and prevent the Config from escaping the package.
 func Load() (Config, error) {
 	var fc fileConfig
 	path := configFilePath()
@@ -58,6 +77,9 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
+// ResolveEditor returns the editor command worktask should launch for
+// interactive edits. The configured Editor wins; otherwise the EDITOR
+// environment variable is used; otherwise the function falls back to vi.
 func (c Config) ResolveEditor() string {
 	if c.Editor != "" {
 		return c.Editor

--- a/internal/id/id.go
+++ b/internal/id/id.go
@@ -1,3 +1,8 @@
+// Package id mints the short hexadecimal identifiers used to name task files.
+//
+// Each call to [New] returns a fresh 8-character lowercase hex string drawn
+// from crypto/rand. The identifier is the stable handle for a task across
+// renames, edits, and the open/closed transition.
 package id
 
 import (
@@ -5,6 +10,9 @@ import (
 	"encoding/hex"
 )
 
+// New returns a freshly minted 8-character lowercase hex task identifier.
+// It draws four bytes from crypto/rand and panics if the system entropy
+// source fails, since the CLI cannot continue without a usable identifier.
 func New() string {
 	var b [4]byte
 	if _, err := rand.Read(b[:]); err != nil {

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -69,6 +69,9 @@ type jsonErrNoMatch struct {
 	OpenTasks []jsonTask `json:"open_tasks"`
 }
 
+// JSONErrorNoMatch renders the no-match error envelope: an object with
+// error="no_match", the offending fragment, and the current open tasks
+// for the user to choose from.
 func JSONErrorNoMatch(fragment string, openTasks []task.Task) ([]byte, error) {
 	tasks := make([]jsonTask, 0, len(openTasks))
 	for _, t := range openTasks {
@@ -77,6 +80,9 @@ func JSONErrorNoMatch(fragment string, openTasks []task.Task) ([]byte, error) {
 	return marshalIndent(jsonErrNoMatch{Error: "no_match", Fragment: fragment, OpenTasks: tasks})
 }
 
+// JSONErrorAmbiguous renders the ambiguous-fragment error envelope: an
+// object with error="ambiguous", the offending fragment, and the
+// candidate tasks the fragment matched.
 func JSONErrorAmbiguous(fragment string, candidates []store.Candidate) ([]byte, error) {
 	matches := make([]jsonMatch, 0, len(candidates))
 	for _, c := range candidates {
@@ -104,6 +110,9 @@ type jsonResearchRun struct {
 	Error       string `json:"error,omitempty"`
 }
 
+// JSONResearchRun renders the per-task summary line emitted on stdout
+// when `worktask research <hash>` completes. The output schema is
+// described in the package documentation.
 func JSONResearchRun(r ResearchRun) ([]byte, error) {
 	return marshalIndent(jsonResearchRun(r))
 }
@@ -130,6 +139,9 @@ type jsonResearchEvent struct {
 	Error       string `json:"error,omitempty"`
 }
 
+// JSONResearchEvent renders one streaming progress event as a
+// newline-terminated single-line JSON object suitable for stdout
+// streaming during a research batch.
 func JSONResearchEvent(e ResearchEvent) ([]byte, error) {
 	out := jsonResearchEvent{
 		Event:       e.Type,
@@ -199,6 +211,9 @@ type jsonResearchSummaryTotals struct {
 	Skipped  int `json:"skipped"`
 }
 
+// JSONResearchSummary renders the final per-batch summary written as
+// the last stdout line when a research sweep completes. Timestamps are
+// emitted as RFC 3339 in UTC.
 func JSONResearchSummary(s ResearchSummary) ([]byte, error) {
 	results := make([]jsonResearchSummaryResult, 0, len(s.Results))
 	for _, r := range s.Results {
@@ -230,10 +245,14 @@ func marshalLine(v any) ([]byte, error) {
 	return buf.Bytes(), nil
 }
 
+// JSONShow renders a single task in the show schema described in the
+// package documentation: the list-element fields plus the full body.
 func JSONShow(t task.Task) ([]byte, error) {
 	return marshalIndent(jsonShowTask{jsonTask: toJSONTask(t), Body: t.Body})
 }
 
+// JSONList renders tasks as the stable list-element schema described
+// in the package documentation, in the order given.
 func JSONList(tasks []task.Task) ([]byte, error) {
 	out := make([]jsonTask, 0, len(tasks))
 	for _, t := range tasks {
@@ -272,6 +291,9 @@ func description(t task.Task) string {
 	return body
 }
 
+// HumanCandidates writes the human-readable disambiguation listing for
+// candidates to w. Description is truncated to 60 columns with a
+// trailing ellipsis. Returns the first write error encountered.
 func HumanCandidates(w io.Writer, candidates []store.Candidate) error {
 	const max = 60
 	for _, c := range candidates {
@@ -286,6 +308,9 @@ func HumanCandidates(w io.Writer, candidates []store.Candidate) error {
 	return nil
 }
 
+// HumanList writes one line per task to w, formatted as
+// "<id>  <yyyy-mm-dd hh:mm>  <description>". Returns the first write
+// error encountered.
 func HumanList(w io.Writer, tasks []task.Task) error {
 	for _, t := range tasks {
 		if _, err := fmt.Fprintf(w, "%s  %s  %s\n", t.ID, t.Created.Format("2006-01-02 15:04"), description(t)); err != nil {

--- a/internal/research/log/log.go
+++ b/internal/research/log/log.go
@@ -10,10 +10,17 @@ import (
 
 const subdir = "research-logs"
 
+// Dir returns the directory under tasksDir where research run logs are
+// written. The directory is not created here; callers create it on
+// demand before writing.
 func Dir(tasksDir string) string {
 	return filepath.Join(tasksDir, subdir)
 }
 
+// Path returns the absolute path of a research log file for the given
+// task hash and run-start time, located under [Dir]. The filename
+// embeds runStart in a filesystem-safe RFC-3339-like form so multiple
+// runs against the same task do not collide.
 func Path(tasksDir, hash string, runStart time.Time) string {
 	name := fmt.Sprintf("%s_%s.jsonl", hash, runStart.Format("2006-01-02T15-04-05"))
 	return filepath.Join(Dir(tasksDir), name)

--- a/internal/research/prompt/prompt.go
+++ b/internal/research/prompt/prompt.go
@@ -33,6 +33,10 @@ func Load(overridePath string) (string, error) {
 	return string(data), nil
 }
 
+// Render parses tmpl as a text/template and executes it against t,
+// returning the rendered prompt. Parse and execution errors are wrapped
+// with a "prompt:" prefix so callers can distinguish template failures
+// from unrelated errors.
 func Render(tmpl string, t task.Task) (string, error) {
 	parsed, err := template.New("prompt").Parse(tmpl)
 	if err != nil {

--- a/internal/research/runner/osexec.go
+++ b/internal/research/runner/osexec.go
@@ -16,6 +16,11 @@ const stderrTailCap = 16 * 1024
 // OSExec spawns the real claude binary via os/exec. Production use only.
 type OSExec struct{}
 
+// Run starts cmd as a child process and returns a reader that streams
+// its stdout. Closing the returned reader waits for the process and, on
+// non-zero exit, returns an error that includes the captured tail of
+// stderr (capped at stderrTailCap bytes). ctx cancellation kills the
+// child via os/exec's context support.
 func (OSExec) Run(ctx context.Context, cmd Command) (io.ReadCloser, error) {
 	c := exec.CommandContext(ctx, cmd.Bin, cmd.Args...)
 	c.Stdin = strings.NewReader(cmd.Stdin)

--- a/internal/slug/slug.go
+++ b/internal/slug/slug.go
@@ -1,7 +1,19 @@
+// Package slug derives the human-readable component of a task filename
+// from a free-form description.
+//
+// Slugs are lowercase, contain only ASCII letters, digits, and single
+// hyphens, never start or end with a hyphen, and are truncated at the last
+// hyphen before maxLen so the result reads as whole words.
 package slug
 
 import "strings"
 
+// Generate returns a filesystem-safe slug derived from description, no
+// longer than maxLen bytes. The slug is lowercased; any run of characters
+// that are not ASCII letters or digits collapses to a single hyphen, and
+// leading or trailing hyphens are trimmed. When the slug exceeds maxLen,
+// it is cut at the last hyphen before the limit so the result ends on a
+// word boundary; if there is no such hyphen, it is hard-truncated.
 func Generate(description string, maxLen int) string {
 	var b strings.Builder
 	b.Grow(len(description))

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -1,3 +1,17 @@
+// Package store is the on-disk task repository: it owns the layout under
+// the configured tasks directory and is the only package that reads from
+// or writes to it.
+//
+// Directory layout. Open tasks live as files under tasks_dir/open and
+// closed tasks under tasks_dir/closed. Filenames follow the
+// "<RFC3339-minute>_<id>[_<slug>].md" pattern. Completing a task moves
+// its file from open to closed; reopening moves it back. Both directories
+// are created lazily on first use.
+//
+// Resolution. Methods that take a fragment look up a task by ID prefix or
+// by description match across the requested subdirectories, returning
+// [ErrNoMatch] when nothing matches and [*ErrAmbiguous] when more than
+// one task matches.
 package store
 
 import (
@@ -15,20 +29,30 @@ import (
 
 const slugMaxLen = 40
 
+// Filter selects which subset of tasks [Store.List] returns.
 type Filter int
 
+// Filter values for [Store.List].
 const (
+	// FilterOpen returns only tasks under the open subdirectory.
 	FilterOpen Filter = iota
+	// FilterClosed returns only tasks under the closed subdirectory.
 	FilterClosed
+	// FilterAll returns open tasks followed by closed tasks.
 	FilterAll
 )
 
+// Store is a handle to the on-disk task repository rooted at TasksDir.
+// Now and NewID are injection points for tests; production callers obtain
+// a Store with sensible defaults via [New].
 type Store struct {
 	TasksDir string
 	Now      func() time.Time
 	NewID    func() string
 }
 
+// New returns a [Store] rooted at tasksDir with production defaults:
+// time.Now for timestamps and crypto-random ids from internal/id.
 func New(tasksDir string) *Store {
 	return &Store{
 		TasksDir: tasksDir,
@@ -37,6 +61,11 @@ func New(tasksDir string) *Store {
 	}
 }
 
+// AddPreserved writes t verbatim to disk, choosing open/ when t.Completed
+// is the zero value and closed/ otherwise. The slug used in the filename
+// is derived from description, not from t.Body. Both subdirectories are
+// created if missing. Intended for migrations and tests that need to
+// place a task with caller-supplied identity and timestamps.
 func (s *Store) AddPreserved(t task.Task, description string) error {
 	openDir := filepath.Join(s.TasksDir, "open")
 	closedDir := filepath.Join(s.TasksDir, "closed")
@@ -60,6 +89,10 @@ func (s *Store) AddPreserved(t task.Task, description string) error {
 	return nil
 }
 
+// Add creates a new open task with description as its body, assigning a
+// fresh ID and the current time as Created. The task file is written
+// under tasks_dir/open and the resulting [task.Task] is returned. The
+// open and closed subdirectories are created if missing.
 func (s *Store) Add(description string) (task.Task, error) {
 	created := s.Now()
 	t := task.Task{
@@ -88,6 +121,11 @@ func (s *Store) Add(description string) (task.Task, error) {
 	return t, nil
 }
 
+// List returns the tasks selected by filter. Open tasks are returned in
+// directory order; closed tasks are sorted by Completed descending and
+// truncated to closedLimit when closedLimit is positive. When filter is
+// [FilterAll], the result is open tasks followed by closed tasks.
+// A missing subdirectory is treated as empty rather than as an error.
 func (s *Store) List(filter Filter, closedLimit int) ([]task.Task, error) {
 	var open, closed []task.Task
 	if filter == FilterOpen || filter == FilterAll {
@@ -145,28 +183,39 @@ type loaded struct {
 	path string
 }
 
+// Candidate is a one-line summary of a task surfaced when fragment
+// resolution is ambiguous.
 type Candidate struct {
 	ID          string
 	Description string
 }
 
+// ErrAmbiguous is returned when a fragment resolves to more than one
+// task. Candidates lists every task that matched the fragment.
 type ErrAmbiguous struct {
 	Fragment   string
 	Candidates []Candidate
 }
 
+// Error implements the error interface for [*ErrAmbiguous].
 func (e *ErrAmbiguous) Error() string {
 	return fmt.Sprintf("store: ambiguous fragment %q (%d candidates)", e.Fragment, len(e.Candidates))
 }
 
+// ErrNoMatch is returned when a fragment matches no task in the
+// requested subdirectories.
 type ErrNoMatch struct {
 	Fragment string
 }
 
+// Error implements the error interface for [*ErrNoMatch].
 func (e *ErrNoMatch) Error() string {
 	return fmt.Sprintf("store: no match for %q", e.Fragment)
 }
 
+// Get resolves fragment against both open and closed tasks and returns
+// the matching [task.Task] together with the raw bytes of its file.
+// Returns [*ErrNoMatch] or [*ErrAmbiguous] when resolution fails.
 func (s *Store) Get(fragment string) (task.Task, []byte, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
@@ -175,6 +224,11 @@ func (s *Store) Get(fragment string) (task.Task, []byte, error) {
 	return l.task, l.raw, nil
 }
 
+// Complete marks the open task identified by fragment as completed at
+// the current time, rewrites the file with the new frontmatter, and
+// moves it from open/ to closed/. Returns [*ErrNoMatch] or
+// [*ErrAmbiguous] when fragment does not resolve to exactly one open
+// task.
 func (s *Store) Complete(fragment string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"open"})
 	if err != nil {
@@ -201,6 +255,10 @@ func (s *Store) Complete(fragment string) (task.Task, error) {
 	return t, nil
 }
 
+// Reopen clears the Completed timestamp on the closed task identified by
+// fragment, rewrites the file, and moves it from closed/ back to open/.
+// Returns [*ErrNoMatch] or [*ErrAmbiguous] when fragment does not
+// resolve to exactly one closed task.
 func (s *Store) Reopen(fragment string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"closed"})
 	if err != nil {
@@ -226,6 +284,10 @@ func (s *Store) Reopen(fragment string) (task.Task, error) {
 	return t, nil
 }
 
+// Update replaces the first body line of the task identified by fragment
+// with newDescription and rewrites the file in place. The remainder of
+// the body and the open/closed location are preserved. Returns
+// [*ErrNoMatch] or [*ErrAmbiguous] when fragment does not resolve.
 func (s *Store) Update(fragment, newDescription string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
@@ -249,6 +311,10 @@ func (s *Store) Update(fragment, newDescription string) (task.Task, error) {
 	return t, nil
 }
 
+// SetResearchMeta updates the last_researched and last_research_log
+// frontmatter fields on the task identified by fragment and rewrites the
+// file in place. The task's open/closed location is preserved. Returns
+// [*ErrNoMatch] or [*ErrAmbiguous] when fragment does not resolve.
 func (s *Store) SetResearchMeta(fragment string, lastResearched time.Time, logPath string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
@@ -267,6 +333,9 @@ func (s *Store) SetResearchMeta(fragment string, lastResearched time.Time, logPa
 	return t, nil
 }
 
+// Path returns the absolute path of the task file identified by
+// fragment. The task may be open or closed. Returns [*ErrNoMatch] or
+// [*ErrAmbiguous] when fragment does not resolve.
 func (s *Store) Path(fragment string) (string, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
@@ -275,6 +344,11 @@ func (s *Store) Path(fragment string) (string, error) {
 	return l.path, nil
 }
 
+// Append concatenates text to the body of the task identified by
+// fragment, inserting a separating newline when the existing body does
+// not already end with one, and rewrites the file in place. The task's
+// open/closed location is preserved. Returns [*ErrNoMatch] or
+// [*ErrAmbiguous] when fragment does not resolve.
 func (s *Store) Append(fragment, text string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -1,3 +1,19 @@
+// Package task is the in-memory model and on-disk codec for a single task
+// file.
+//
+// On-disk format. A task file is YAML-style frontmatter delimited by lines
+// containing only "---", followed by a free-form markdown body. The
+// frontmatter carries `id`, `created`, optional `completed`, optional
+// `last_researched`, and optional `last_research_log`; all timestamps are
+// RFC 3339. The body is everything after the trailing delimiter and is
+// preserved verbatim. The user-visible specification of this format,
+// including which fields are stable and how they interact with the CLI,
+// lives on the docs site at
+// <https://jvcorredor.github.io/worktask/storage/>; this package
+// implements that contract and does not duplicate it.
+//
+// [Encode] and [Decode] are the only entry points; the rest of the codec
+// is internal.
 package task
 
 import (
@@ -7,6 +23,9 @@ import (
 	"time"
 )
 
+// Task is the in-memory representation of one task file. The zero value
+// of Completed and LastResearched means "not set" and is encoded by
+// omitting the corresponding frontmatter field.
 type Task struct {
 	ID              string
 	Created         time.Time
@@ -18,6 +37,12 @@ type Task struct {
 
 const delim = "---\n"
 
+// Encode serialises t as the bytes of a task file. The output is the
+// frontmatter described in the package documentation followed by t.Body
+// verbatim. Zero-valued Completed and LastResearched fields are omitted
+// from the frontmatter; an empty LastResearchLog is omitted as well.
+// Encode never returns an error in the current implementation, but the
+// signature reserves room for future format-validation failures.
 func Encode(t Task) ([]byte, error) {
 	var b bytes.Buffer
 	b.WriteString(delim)
@@ -37,6 +62,13 @@ func Encode(t Task) ([]byte, error) {
 	return b.Bytes(), nil
 }
 
+// Decode parses the bytes of a task file into a [Task]. It is the
+// inverse of [Encode] for any value Encode produces. Decode requires the
+// leading and trailing "---" frontmatter delimiters and rejects malformed
+// frontmatter lines or unparseable RFC 3339 timestamps. Unknown
+// frontmatter keys are tolerated and ignored so older binaries can read
+// task files written by newer ones. The body is returned verbatim,
+// without trimming.
 func Decode(data []byte) (Task, error) {
 	s := string(data)
 	if !strings.HasPrefix(s, delim) {

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,3 +1,7 @@
+// Command worktask-migrate is the one-shot migration tool that promotes
+// the legacy WORKING.md working log into the per-task file layout under
+// the configured tasks directory. The transformation contract is
+// documented on [Run].
 package main
 
 import (
@@ -16,6 +20,25 @@ const tsLayout = "2006-01-02 15:04"
 
 var taskLineRe = regexp.MustCompile(`^(\d{4}-\d{2}-\d{2} \d{2}:\d{2}) \[task ([0-9a-f]{8})(?: — completed (\d{4}-\d{2}-\d{2} \d{2}:\d{2}))?\]: (.+)$`)
 
+// Run migrates the legacy working-log file at workingMdPath into the
+// per-task layout owned by s.
+//
+// Contract:
+//
+//   - Every "[task <id>]:" line in the working log becomes a task file
+//     under s, preserving the original ID and Created timestamp parsed
+//     from the line. Lines marked "— completed <ts>" populate Completed
+//     so the task lands in closed/.
+//   - Indented and blank lines that follow a task line are folded into
+//     that task's body in source order; trailing blanks are returned to
+//     the working log instead of being attached to the task.
+//   - Non-task lines are preserved in the rewritten working log in their
+//     original order.
+//   - The rewritten working log is written back to workingMdPath after
+//     all task files have been created.
+//   - Run is not idempotent: calling it on a working log that contains
+//     no task lines returns an error so a second invocation does not
+//     silently truncate state.
 func Run(workingMdPath string, s *store.Store) error {
 	data, err := os.ReadFile(workingMdPath)
 	if err != nil {


### PR DESCRIPTION
## Summary
- Backfill package and exported-symbol doc comments across `internal/{id,slug,config,task,store}`, `cmd`, and `migrate`, plus the gaps lint flagged in `internal/render` and `internal/research/{log,prompt,runner}`.
- `task.Task`/`Encode`/`Decode` document the on-disk task file format and reference (not duplicate) the docs site spec; `store.Store`'s public methods document their open/closed directory side effects; `cmd` documents the cobra command tree; `migrate.Run` documents the working-log migration contract.
- Flip on `revive.exported` and remove the `-ST1000` exclude in `.golangci.yml` so the standard is self-enforcing. Add a "Go source-level docs" section to `CLAUDE.md` pointing at `go doc <pkg>` and `golangci-lint run`.

Closes #11.

## Test plan
- [x] `golangci-lint run` is green (0 issues across the whole module).
- [x] Removing a doc comment from a freshly-backfilled symbol (`internal/id.New`) makes `golangci-lint run` fail with the expected `revive: exported` error; comment restored.
- [x] `go doc ./internal/{id,slug,config,task,store} ./cmd` each render an informative package overview.
- [x] `go test ./...` passes.
- [x] `go vet ./...` is clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)