### PR TITLE
build: add justfile with Go recipes and ci aggregate

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 .scratch/
+bin/

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -258,10 +258,10 @@ func TestLoad_rejectsWriteCapableEntriesInExtraTools(t *testing.T) {
 	// with a write-capable extra never escapes the package.
 	const goodEntry = "mcp__claude_ai_Slack__slack_read_thread"
 	cases := []struct {
-		name     string
-		extras   []string
-		bad      string
-		wantIdx  string // bracketed form expected in the error message
+		name    string
+		extras  []string
+		bad     string
+		wantIdx string // bracketed form expected in the error message
 	}{
 		{"bareEdit", []string{"Edit"}, "Edit", "[0]"},
 		{"bareWrite", []string{goodEntry, "Write"}, "Write", "[1]"},

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -39,11 +39,11 @@ func TestRoundTrip_researchFieldsSet(t *testing.T) {
 	created := time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC)
 	lastResearched := time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC)
 	original := Task{
-		ID:               "abcdef12",
-		Created:          created,
-		LastResearched:   lastResearched,
-		LastResearchLog:  "research-logs/abcdef12_2026-05-01T14-00.jsonl",
-		Body:             "buy milk\n",
+		ID:              "abcdef12",
+		Created:         created,
+		LastResearched:  lastResearched,
+		LastResearchLog: "research-logs/abcdef12_2026-05-01T14-00.jsonl",
+		Body:            "buy milk\n",
 	}
 	data, err := Encode(original)
 	if err != nil {

--- a/justfile
+++ b/justfile
@@ -1,0 +1,34 @@
+# List every recipe in this justfile
+default:
+    @just --list
+
+# Compile the worktask CLI to ./bin/worktask
+build:
+    go build -o ./bin/worktask .
+
+# Run the Go test suite
+test:
+    go test ./...
+
+# Run go vet across all packages
+vet:
+    go vet ./...
+
+# Format every Go file in place
+fmt:
+    gofmt -w .
+
+# Fail if any Go file is not gofmt-clean (used by `ci`)
+fmt-check:
+    @out=$(gofmt -l .); if [ -n "$out" ]; then echo "Unformatted Go files:"; echo "$out"; exit 1; fi
+
+# Remove build artifacts under ./bin
+clean:
+    rm -rf ./bin
+
+# Placeholder for the lint gate; wired up in #10
+lint:
+    @echo "lint is not yet implemented; see https://github.com/jvcorredor/worktask/issues/10" >&2; exit 1
+
+# Run the full local CI gate (fmt-check, vet, test) in workflow order
+ci: fmt-check vet test


### PR DESCRIPTION
## Summary
- Adds a top-level `justfile` wrapping the everyday Go operations (`build`, `test`, `vet`, `fmt`, `fmt-check`, `clean`) and exposing a single `ci` recipe that runs `fmt-check`, `vet`, `test` in that order — so the local pre-PR check and the (eventual) GitHub Actions Go gate share one definition by name.
- `default` is `@just --list` for self-discovery; `lint` is a placeholder that errors with a pointer to #10 until that gate lands.
- File is byte-identical to `just --fmt --unstable` output. Each recipe carries a one-line `#`-comment so `just --list` is self-documenting.
- `bin/` is gitignored. No GitHub Actions workflow is modified.

A separate `chore:` commit cleans up pre-existing gofmt drift in two test files (`internal/config/config_test.go`, `internal/task/task_test.go`) so `just ci` passes on a clean checkout.

Closes #13. Refs #15.

## Test plan
- [x] `just` (no args) prints the recipe list
- [x] `just build` produces `./bin/worktask` and the binary runs
- [x] `just test`, `just vet`, `just fmt`, `just clean` each behave as named
- [x] `just fmt-check` exits non-zero on intentionally-unformatted Go and zero on a clean tree
- [x] `just ci` runs `fmt-check` → `vet` → `test` and short-circuits on the first failure
- [x] `just lint` exits non-zero with a message pointing at #10
- [x] `just --fmt --unstable` is a no-op against the committed file
- [x] No file under `.github/workflows/` is modified