### PR TITLE
build(justfile): add docs-dev and docs-build recipes

### DIFF
--- a/justfile
+++ b/justfile
@@ -26,6 +26,14 @@ fmt-check:
 clean:
     rm -rf ./bin
 
+# Boot the Astro dev server with docs/ as the working directory
+docs-dev:
+    cd docs && yarn dev
+
+# Install (immutable) and build the Astro docs site, producing docs/dist/
+docs-build:
+    cd docs && yarn install --immutable && yarn build
+
 # Placeholder for the lint gate; wired up in #10
 lint:
     @echo "lint is not yet implemented; see https://github.com/jvcorredor/worktask/issues/10" >&2; exit 1


### PR DESCRIPTION
## Summary

- Add `docs-dev` recipe — `cd docs && yarn dev` for the Astro dev loop.
- Add `docs-build` recipe — `cd docs && yarn install --immutable && yarn build`, matching docs CI's lockfile-respecting flags.
- Both recipes have the standard one-line `#`-comment description; file is byte-identical to `just --fmt --unstable`.

## Test plan

- [x] `just docs-build` from repo root produces `docs/dist/` (verified locally — 8 pages built, `dist/index.html` present)
- [x] `just docs-dev` boots the Astro dev server with `docs/` as cwd (verified — `astro v6.2.1 ready`, Local URL `http://localhost:4321/worktask`)
- [x] `just --fmt --unstable --check` exits 0
- [x] `docs/package.json` and `.github/workflows/docs.yml` unchanged (`git diff --name-only origin/main` shows only `justfile`)
- [x] `just ci` green

Closes: #16

🤖 Generated with [Claude Code](https://claude.com/claude-code)