### PR TITLE
docs(claude): point CLAUDE.md at the justfile

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,14 @@ Any PR that changes user-visible CLI surface — subcommands, flags, JSON schema
 
 The vendored reference slash command at `docs/src/content/docs/examples/worktask-slash-command.md` is part of that contract. If a JSON schema or error-envelope change requires updating how an agent wraps the CLI, the slash-command file is updated in the same PR as the schema change.
 
+## Local commands
+
+This repo uses `just` as a task runner; install it once with `brew install just` (or your platform's equivalent). Beyond that the only dev dependencies are Go and Yarn.
+
+Run `just --list` to discover the available recipes — every recipe carries a one-line description.
+
+Run `just ci` before opening a Go PR; it runs `fmt-check`, `vet`, and `test` locally so failures surface before pushing.
+
 ## Go source-level docs
 
 Exported Go symbols carry doc comments in the standard Go convention: a complete sentence that begins with the identifier name. Every package has a package doc comment that explains what it does and any contracts (on-disk format, stable schema, side effects).


### PR DESCRIPTION
## Summary

- Add a `## Local commands` section to `CLAUDE.md` that routes a cold-loaded agent or contributor to the justfile as the entry point for available operations.
- Names `just --list` as the discovery command, `just ci` as the pre-PR gate for Go work, and `brew install just` as the only required dev dependency beyond Go and Yarn.
- Existing `## Documentation` and slash-command-contract sections are preserved unchanged; no file outside `CLAUDE.md` is modified.

Refs: #17
Closes: #13

## Test plan

- [x] `CLAUDE.md` has a section directing readers to `just --list` and `just ci`
- [x] `CLAUDE.md` mentions `brew install just` once as a dev dependency
- [x] Existing docs-site and slash-command sections of `CLAUDE.md` are preserved unchanged
- [x] No file outside `CLAUDE.md` is modified

🤖 Generated with [Claude Code](https://claude.com/claude-code)