### PR TITLE
feat(cli): version reporting via --version flag and version subcommand

### DIFF
--- a/cmd/version.go
+++ b/cmd/version.go
@@ -1,0 +1,44 @@
+package cmd
+
+import (
+	"encoding/json"
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	intversion "github.com/jvcorredor/worktask/internal/version"
+)
+
+var versionCmd = &cobra.Command{
+	Use:   "version",
+	Short: "Print the worktask version",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		info := intversion.Get()
+		switch format {
+		case formatJSON:
+			payload := struct {
+				Version string `json:"version"`
+				Commit  string `json:"commit"`
+				Date    string `json:"date"`
+				Source  string `json:"source"`
+			}{info.Version, info.Commit, info.Date, info.Source}
+			data, err := json.MarshalIndent(payload, "", "  ")
+			if err != nil {
+				return err
+			}
+			data = append(data, '\n')
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		case formatHuman:
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "worktask %s (commit %s, built %s)\n", info.Version, info.Commit, info.Date)
+			return err
+		default:
+			return fmt.Errorf("unknown format: %s", format)
+		}
+	},
+}
+
+func init() {
+	rootCmd.AddCommand(versionCmd)
+}

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -1,0 +1,146 @@
+package cmd
+
+import (
+	"bytes"
+	"encoding/json"
+	"strings"
+	"testing"
+
+	intversion "github.com/jvcorredor/worktask/internal/version"
+)
+
+// setVersionForTest seeds the internal/version package's ldflags landing
+// zone so version.Get() returns the chosen identity for the duration of
+// the test. The ldflags branch wins over runtime/debug.ReadBuildInfo, so
+// no buildinfo suppression is needed at this layer.
+func setVersionForTest(t *testing.T, v, c, d string) {
+	t.Helper()
+	prevV, prevC, prevD := intversion.Version, intversion.Commit, intversion.Date
+	t.Cleanup(func() {
+		intversion.Version = prevV
+		intversion.Commit = prevC
+		intversion.Date = prevD
+	})
+	intversion.Version = v
+	intversion.Commit = c
+	intversion.Date = d
+}
+
+func runVersionCmd(t *testing.T, fmtFlag string) (stdout, stderr bytes.Buffer) {
+	t.Helper()
+	prevFormat := format
+	format = fmtFlag
+	t.Cleanup(func() { format = prevFormat })
+
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"version"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute version: %v (stderr=%s)", err, stderr.String())
+	}
+	return stdout, stderr
+}
+
+// TestRootCmdVersionFlag is the cobra wiring test: after the cmd package
+// init runs, rootCmd.Version must be populated from version.Get(), so
+// `worktask --version` and `worktask -v` print a meaningful line via
+// cobra's built-in version flag handling.
+func TestRootCmdVersionFlag(t *testing.T) {
+	setVersionForTest(t, "v9.9.9", "abc1234", "2026-05-03T12:00:00Z")
+	syncVersion()
+	t.Cleanup(syncVersion)
+
+	if rootCmd.Version != "v9.9.9" {
+		t.Errorf("rootCmd.Version = %q; want %q", rootCmd.Version, "v9.9.9")
+	}
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"--version"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute --version: %v (stderr=%s)", err, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "v9.9.9") {
+		t.Errorf("--version output %q should contain v9.9.9", stdout.String())
+	}
+}
+
+func TestVersionCmd(t *testing.T) {
+	cases := []struct {
+		name        string
+		format      string
+		injected    [3]string // version, commit, date
+		assertHuman func(t *testing.T, out string)
+		assertJSON  func(t *testing.T, out string)
+	}{
+		{
+			name:     "human format prints a single line containing the version",
+			format:   formatHuman,
+			injected: [3]string{"v1.2.3", "deadbeef", "2026-05-03T10:00:00Z"},
+			assertHuman: func(t *testing.T, out string) {
+				if !strings.HasSuffix(out, "\n") {
+					t.Errorf("human output should end in newline; got %q", out)
+				}
+				trimmed := strings.TrimRight(out, "\n")
+				if strings.Contains(trimmed, "\n") {
+					t.Errorf("human output should be a single line; got %q", out)
+				}
+				if !strings.Contains(trimmed, "v1.2.3") {
+					t.Errorf("human output %q should contain version v1.2.3", trimmed)
+				}
+			},
+		},
+		{
+			name:     "json format emits a well-formed object with documented keys",
+			format:   formatJSON,
+			injected: [3]string{"v1.2.3", "deadbeef", "2026-05-03T10:00:00Z"},
+			assertJSON: func(t *testing.T, out string) {
+				var got map[string]any
+				if err := json.Unmarshal([]byte(out), &got); err != nil {
+					t.Fatalf("json output is not well-formed: %v\n%s", err, out)
+				}
+				for _, key := range []string{"version", "commit", "date"} {
+					if _, ok := got[key]; !ok {
+						t.Errorf("json output missing key %q: %v", key, got)
+					}
+				}
+				if got["version"] != "v1.2.3" {
+					t.Errorf("json version = %v; want v1.2.3", got["version"])
+				}
+				if got["commit"] != "deadbeef" {
+					t.Errorf("json commit = %v; want deadbeef", got["commit"])
+				}
+				if got["date"] != "2026-05-03T10:00:00Z" {
+					t.Errorf("json date = %v; want 2026-05-03T10:00:00Z", got["date"])
+				}
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			setVersionForTest(t, tc.injected[0], tc.injected[1], tc.injected[2])
+
+			stdout, _ := runVersionCmd(t, tc.format)
+
+			if tc.assertHuman != nil {
+				tc.assertHuman(t, stdout.String())
+			}
+			if tc.assertJSON != nil {
+				tc.assertJSON(t, stdout.String())
+			}
+		})
+	}
+}

--- a/cmd/version_vars.go
+++ b/cmd/version_vars.go
@@ -1,0 +1,43 @@
+package cmd
+
+import (
+	intversion "github.com/jvcorredor/worktask/internal/version"
+)
+
+// Version, Commit, and Date are the cobra-side ldflags landing zone.
+// Release builds inject them via
+//
+//	go build -ldflags="-X github.com/jvcorredor/worktask/cmd.Version=v1.2.3 \
+//	                   -X github.com/jvcorredor/worktask/cmd.Commit=$SHA \
+//	                   -X github.com/jvcorredor/worktask/cmd.Date=$ISO8601"
+//
+// They mirror the convention of putting build identity at the binary's
+// command package; syncVersion forwards them into internal/version where
+// the resolution rules live.
+var (
+	Version string
+	Commit  string
+	Date    string
+)
+
+func init() {
+	syncVersion()
+}
+
+// syncVersion copies the cmd-side ldflags landing zone into the
+// internal/version package and refreshes rootCmd.Version so cobra's
+// built-in --version / -v handling reports the resolved value. It is
+// idempotent and safe to call multiple times; tests use it to apply
+// new fixture values after rewriting the version vars.
+func syncVersion() {
+	if Version != "" {
+		intversion.Version = Version
+	}
+	if Commit != "" {
+		intversion.Commit = Commit
+	}
+	if Date != "" {
+		intversion.Date = Date
+	}
+	rootCmd.Version = intversion.Get().Version
+}

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -5,11 +5,13 @@ description: Subcommand reference for the worktask CLI — flags, examples, and 
 
 Every subcommand `worktask` exposes is documented on this page. For the on-disk shape of task files, see [File & storage format](./storage.md). For JSON output and error envelopes, see [Agentic usage](./agentic.md).
 
-## Global flag
+## Global flags
 
 `--format=human|json` (default `human`).
 
 JSON output is intended for agentic consumers; the schema is documented as stable. Human output is the default and is what you see when running `worktask` directly in a terminal.
+
+`--version` (alias `-v`) prints the binary's version on a single line and exits — see the [`version`](#version) subcommand below for the underlying resolution rules.
 
 ## Subcommands at a glance
 
@@ -23,6 +25,7 @@ worktask complete <fragment>
 worktask reopen <fragment>
 worktask edit <fragment>
 worktask research [<fragment>]
+worktask version
 ```
 
 `<fragment>` is anything that resolves to a single task. See [Match resolution](#match-resolution) below.
@@ -134,6 +137,25 @@ Flags:
 The shipped binary's `--allowed-tools` baseline contains five built-in read-only tools and nothing else: `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`. To extend the allowlist with MCP tools or pattern-restricted `Bash(...)` invocations on a per-machine basis, add a [`research_extra_tools`](./config.md#research_extra_tools) block to your `config.toml`. There is no `--extra-tool` flag; tool availability is a per-machine property, not a per-invocation one.
 
 JSON output is documented in [Agentic usage](./agentic.md).
+
+## `version`
+
+Prints the binary's build identity. The same identity is what `worktask --version` and `worktask -v` report on a single line via cobra's built-in version flag.
+
+```
+$ worktask version
+worktask v1.2.3 (commit abcdef1, built 2026-05-03T10:00:00Z)
+
+$ worktask --format=json version
+{
+  "version": "v1.2.3",
+  "commit": "abcdef1",
+  "date": "2026-05-03T10:00:00Z",
+  "source": "ldflags"
+}
+```
+
+The JSON schema is `{"version": string, "commit": string, "date": string, "source": string}`. The `source` field records which resolution branch produced the values: `"ldflags"` for release builds with `-ldflags="-X ..."`, `"buildinfo"` for binaries produced by `go install module@version` (where the version is read from the Go module proxy via `runtime/debug.ReadBuildInfo`), and `"default"` for unannotated developer builds (which report `"version": "dev"`).
 
 ## Match resolution
 

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,0 +1,97 @@
+// Package version reports the worktask binary's build identity.
+//
+// Resolution order, hidden behind [Get]:
+//
+//  1. ldflags-injected values written into [Version], [Commit], [Date]
+//     by `go build -ldflags="-X ..."`.
+//  2. module-proxy metadata returned by [runtime/debug.ReadBuildInfo]
+//     for binaries produced by `go install module@version`.
+//  3. sentinel defaults (`dev`, `unknown`) for unannotated developer
+//     builds.
+//
+// The [Info.Source] field records which branch produced the result so
+// callers and tests can distinguish them.
+package version
+
+import "runtime/debug"
+
+// Version, Commit, and Date are the ldflags landing zone inside this
+// package. They are intentionally exported so a release build can wire
+// them via `-ldflags="-X github.com/jvcorredor/worktask/internal/version.Version=v1.2.3 ..."`.
+// Unset, [Get] falls back to module-proxy metadata or sentinel defaults.
+var (
+	Version string
+	Commit  string
+	Date    string
+)
+
+// readBuildInfo is a package-level indirection over
+// [runtime/debug.ReadBuildInfo] so tests can swap in fixtures without
+// rebuilding the test binary with ldflags.
+var readBuildInfo = debug.ReadBuildInfo
+
+// Info is the resolved version identity for the running binary.
+//
+// Source records which resolution branch produced the values:
+// "ldflags", "buildinfo", or "default". Callers should treat the field
+// as part of the contract rather than a debugging aid; the JSON
+// rendering of `worktask version --format=json` exposes it.
+type Info struct {
+	Version string
+	Commit  string
+	Date    string
+	Source  string
+}
+
+// Get resolves the binary's version identity using the order documented
+// on the package. It never returns an error: an unannotated dev build
+// produces ("dev", "unknown", "unknown", "default") rather than failing.
+func Get() Info {
+	if Version != "" {
+		return Info{
+			Version: Version,
+			Commit:  orUnknown(Commit),
+			Date:    orUnknown(Date),
+			Source:  "ldflags",
+		}
+	}
+	if info, ok := readBuildInfo(); ok && info.Main.Version != "" && info.Main.Version != "(devel)" {
+		commit, date := vcsFromBuildInfo(info)
+		return Info{
+			Version: info.Main.Version,
+			Commit:  commit,
+			Date:    date,
+			Source:  "buildinfo",
+		}
+	}
+	return Info{
+		Version: "dev",
+		Commit:  "unknown",
+		Date:    "unknown",
+		Source:  "default",
+	}
+}
+
+func vcsFromBuildInfo(info *debug.BuildInfo) (commit, date string) {
+	commit, date = "unknown", "unknown"
+	for _, s := range info.Settings {
+		switch s.Key {
+		case "vcs.revision":
+			if s.Value != "" {
+				commit = s.Value
+			}
+		case "vcs.time":
+			if s.Value != "" {
+				date = s.Value
+			}
+		}
+	}
+	return commit, date
+}
+
+func orUnknown(s string) string {
+	if s == "" {
+		return "unknown"
+	}
+	return s
+}

--- a/internal/version/version_test.go
+++ b/internal/version/version_test.go
@@ -1,0 +1,136 @@
+package version
+
+import (
+	"runtime/debug"
+	"testing"
+)
+
+// resetForTest restores package state to what it would be at process start
+// for a binary built without ldflags and outside `go install`. Tests should
+// defer it via t.Cleanup so they do not leak state into siblings.
+func resetForTest(t *testing.T) {
+	t.Helper()
+	prevV, prevC, prevD := Version, Commit, Date
+	prevBI := readBuildInfo
+	t.Cleanup(func() {
+		Version, Commit, Date = prevV, prevC, prevD
+		readBuildInfo = prevBI
+	})
+	Version = ""
+	Commit = ""
+	Date = ""
+	readBuildInfo = func() (*debug.BuildInfo, bool) { return nil, false }
+}
+
+func TestGet_baselineReturnsSentinels(t *testing.T) {
+	resetForTest(t)
+
+	got := Get()
+
+	if got.Version != "dev" {
+		t.Errorf("Version = %q; want %q", got.Version, "dev")
+	}
+	if got.Commit != "unknown" {
+		t.Errorf("Commit = %q; want %q", got.Commit, "unknown")
+	}
+	if got.Date != "unknown" {
+		t.Errorf("Date = %q; want %q", got.Date, "unknown")
+	}
+	if got.Source != "default" {
+		t.Errorf("Source = %q; want %q", got.Source, "default")
+	}
+}
+
+func TestGet_buildInfoFallback(t *testing.T) {
+	resetForTest(t)
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{
+			Main: debug.Module{Version: "v0.4.2"},
+			Settings: []debug.BuildSetting{
+				{Key: "vcs.revision", Value: "cafef00dcafef00dcafef00dcafef00dcafef00d"},
+				{Key: "vcs.time", Value: "2026-04-30T08:15:00Z"},
+			},
+		}, true
+	}
+
+	got := Get()
+
+	if got.Version != "v0.4.2" {
+		t.Errorf("Version = %q; want %q", got.Version, "v0.4.2")
+	}
+	if got.Commit != "cafef00dcafef00dcafef00dcafef00dcafef00d" {
+		t.Errorf("Commit = %q; want vcs.revision value", got.Commit)
+	}
+	if got.Date != "2026-04-30T08:15:00Z" {
+		t.Errorf("Date = %q; want vcs.time value", got.Date)
+	}
+	if got.Source != "buildinfo" {
+		t.Errorf("Source = %q; want %q", got.Source, "buildinfo")
+	}
+}
+
+func TestGet_buildInfoWithoutVCSSettings(t *testing.T) {
+	resetForTest(t)
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "v0.4.2"}}, true
+	}
+
+	got := Get()
+
+	if got.Version != "v0.4.2" {
+		t.Errorf("Version = %q; want %q", got.Version, "v0.4.2")
+	}
+	if got.Commit != "unknown" {
+		t.Errorf("Commit = %q; want %q when vcs settings are absent", got.Commit, "unknown")
+	}
+	if got.Date != "unknown" {
+		t.Errorf("Date = %q; want %q when vcs settings are absent", got.Date, "unknown")
+	}
+	if got.Source != "buildinfo" {
+		t.Errorf("Source = %q; want %q", got.Source, "buildinfo")
+	}
+}
+
+func TestGet_buildInfoMainVersionDevlIsTreatedAsDefault(t *testing.T) {
+	// `go run` and bare `go build` produce BuildInfo whose Main.Version is
+	// "(devel)". That is not a useful version string — the package treats
+	// it as if no buildinfo were available so the "dev" sentinel takes
+	// over instead of being surfaced to the user.
+	resetForTest(t)
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "(devel)"}}, true
+	}
+
+	got := Get()
+
+	if got.Version != "dev" || got.Source != "default" {
+		t.Errorf("Get() with Main.Version=(devel) = %+v; want Version=dev Source=default", got)
+	}
+}
+
+func TestGet_ldflagsValuesWin(t *testing.T) {
+	resetForTest(t)
+	Version = "v1.2.3"
+	Commit = "deadbeef"
+	Date = "2026-05-03T10:00:00Z"
+
+	// Even if ReadBuildInfo would return something, ldflags must win.
+	readBuildInfo = func() (*debug.BuildInfo, bool) {
+		return &debug.BuildInfo{Main: debug.Module{Version: "v0.0.1"}}, true
+	}
+
+	got := Get()
+
+	if got.Version != "v1.2.3" {
+		t.Errorf("Version = %q; want %q", got.Version, "v1.2.3")
+	}
+	if got.Commit != "deadbeef" {
+		t.Errorf("Commit = %q; want %q", got.Commit, "deadbeef")
+	}
+	if got.Date != "2026-05-03T10:00:00Z" {
+		t.Errorf("Date = %q; want %q", got.Date, "2026-05-03T10:00:00Z")
+	}
+	if got.Source != "ldflags" {
+		t.Errorf("Source = %q; want %q", got.Source, "ldflags")
+	}
+}


### PR DESCRIPTION
## Summary

- New `internal/version` package hides dual-source resolution behind a single `Get() Info` call: ldflags wins, then `runtime/debug.ReadBuildInfo()` (module proxy version + vcs.revision/vcs.time), then `dev`/`unknown` sentinels. The `Source` field records which branch fired.
- Cobra wiring: cmd-side `Version`/`Commit`/`Date` package vars are the ldflags landing zone; `syncVersion()` forwards them into `internal/version` and refreshes `rootCmd.Version` so `worktask --version` and `-v` print a meaningful line.
- `worktask version` subcommand prints a single human line by default and stable JSON (`{version, commit, date, source}`) under `--format=json`.
- `docs/src/content/docs/cli.md` documents the flag, subcommand, JSON schema, and resolution rules in the same PR.

## Test plan

- [x] `internal/version` unit tests cover the three required cases — baseline sentinels, ldflags-set values win, `ReadBuildInfo` fallback (with and without `vcs.*` settings) — plus the `(devel)` edge case. `Source` field is asserted in every case.
- [x] Cobra-level table-driven test in `cmd/version_test.go` (mirrors `cmd/research_skip_test.go`) asserts human-format is single-line + contains version, and JSON-format is well-formed + contains documented keys.
- [x] Cobra-level test for `--version` flag wiring (`TestRootCmdVersionFlag`).
- [x] `just ci` green locally (fmt-check, vet, test).
- [x] `golangci-lint run` reports 0 issues.
- [x] Manual smoke tests on the built binary:
  - `go build .` → `worktask --version` reports `worktask version dev`; `worktask --format=json version` reports `"source": "default"`.
  - `go build -ldflags="-X .../cmd.Version=v1.2.3 -X .../cmd.Commit=abcdef1 -X .../cmd.Date=..."` → reports the injected values with `"source": "ldflags"`.

Refs #29

🤖 Generated with [Claude Code](https://claude.com/claude-code)