### PR TITLE
ci(dependabot): enable weekly version updates for gomod and actions

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,33 @@
+version: 2
+updates:
+  - package-ecosystem: gomod
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      gomod-minor-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    open-pull-requests-limit: 5
+    labels:
+      - dependencies
+    commit-message:
+      prefix: chore
+      include: scope
+    groups:
+      actions-minor-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary

- Adds `.github/dependabot.yml` (schema v2) for the `gomod` and `github-actions` ecosystems at the repo root, with weekly cadence, an open-PR cap of 5, a single minor+patch group per ecosystem (`gomod-minor-patch`, `actions-minor-patch`), and a `dependencies` label so the bot's PRs stay out of the human triage queue.
- Commit messages use `chore` with scope, matching the repo's Conventional Commits convention.
- Major updates remain ungrouped so each breaking bump gets its own PR and isolated CI signal.

The `dependencies` label was created on the repo (`gh label create`) before this PR so Dependabot's auto-labeling does not silently fail on first run.

After merge, the maintainer still needs to flip the two settings toggles in *Settings → Code security and analysis* — "Dependabot alerts" and "Dependabot security updates" — to complete the parent issue (#34). That step cannot be performed from a PR.

Closes #36
Refs #34

## Test plan

- [x] `.github/dependabot.yml` parses as valid YAML and matches the schema-v2 shape (`version: 2`, two `updates:` entries, both with `gomod`/`github-actions` ecosystems, weekly schedule, `open-pull-requests-limit: 5`, `labels: [dependencies]`, `commit-message.prefix: chore` + `include: scope`, one minor+patch group per ecosystem).
- [x] `dependencies` label exists on the repo (verified via `gh label list`).
- [ ] After merge, a Dependabot PR opens within one weekly cycle; the PR is labeled `dependencies` (not `needs-triage`); the existing `go.yml` workflow runs against it; `just ci` passes locally on the bumped tree.