### PR TITLE
feat(cli)!: rename worktask complete to worktask close

### DIFF
--- a/cmd/close.go
+++ b/cmd/close.go
@@ -4,8 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
-var completeCmd = &cobra.Command{
-	Use:   "complete <fragment>",
+var closeCmd = &cobra.Command{
+	Use:   "close <fragment>",
 	Short: "Move a task from open to closed and stamp completed",
 	Args:  cobra.ExactArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
@@ -14,15 +14,15 @@ var completeCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		t, err := s.Complete(fragment)
+		t, err := s.Close(fragment)
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
-		cmd.Printf("completed %s\n", t.ID)
+		cmd.Printf("closed %s\n", t.ID)
 		return nil
 	},
 }
 
 func init() {
-	rootCmd.AddCommand(completeCmd)
+	rootCmd.AddCommand(closeCmd)
 }

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -1,0 +1,93 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+// TestCloseCmd_movesOpenTaskToClosedAndPrintsClosedID is the end-to-end
+// test for `worktask close <fragment>`: the open task file moves under
+// closed/, the frontmatter gets a `completed:` stamp, and stdout reads
+// `closed <id>` (the verb matches the new subcommand name and the
+// inverse `reopen`).
+func TestCloseCmd_movesOpenTaskToClosedAndPrintsClosedID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tk := task.Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Body:    "buy milk\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("task.Encode: %v", err)
+	}
+	openPath := filepath.Join(openDir, "2026-04-29T11-30_abcdef12_buy-milk.md")
+	if err := os.WriteFile(openPath, raw, 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"close", "abcdef12"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute close: %v (stderr=%s)", err, stderr.String())
+	}
+
+	if got, want := strings.TrimRight(stdout.String(), "\n"), "closed abcdef12"; got != want {
+		t.Errorf("close stdout = %q; want %q", got, want)
+	}
+
+	if _, err := os.Stat(openPath); !os.IsNotExist(err) {
+		t.Errorf("expected open file to be gone, stat err = %v", err)
+	}
+	closedPath := filepath.Join(tmp, "worktask", "closed", "2026-04-29T11-30_abcdef12_buy-milk.md")
+	if _, err := os.Stat(closedPath); err != nil {
+		t.Errorf("expected closed file at %s: %v", closedPath, err)
+	}
+}
+
+// TestCompleteCmd_isRemoved enforces the no-alias acceptance criterion:
+// after the rename, `worktask complete <fragment>` must error out as an
+// unknown subcommand so that agents using the JSON envelope re-pin to
+// the new name rather than silently keep working against a deprecated
+// alias.
+func TestCompleteCmd_isRemoved(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"complete", "abcdef12"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for `complete`, got nil (stdout=%q)", stdout.String())
+	}
+	if !strings.Contains(err.Error(), `unknown command "complete"`) {
+		t.Errorf("expected 'unknown command \"complete\"', got %v", err)
+	}
+}

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,7 +1,7 @@
 // Package cmd assembles the worktask cobra command tree.
 //
 // The root command lives in this file as rootCmd; each subcommand —
-// add, list, show, complete, reopen, edit, update, append,
+// add, list, show, close, reopen, edit, update, append,
 // research, research-log — is defined in its own file in this package
 // and attached to rootCmd from that file's init(). Per-command flags,
 // help strings (Cobra's Short and Long), and Run functions are kept

--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -48,7 +48,7 @@ The reference slash command for Claude Code is a thin wrapper. It does not read 
 
 | Subcommands | How the wrapper invokes them | Notes |
 |-------------|------------------------------|-------|
-| `add`, `list`, `show`, `update`, `append`, `complete`, `reopen` | Shell out with `--format=json`. On exit 0, pass success output through. On non-zero exit, branch on the `error` discriminator. | Uniform shape across all of them. |
+| `add`, `list`, `show`, `update`, `append`, `close`, `reopen` | Shell out with `--format=json`. On exit 0, pass success output through. On non-zero exit, branch on the `error` discriminator. | Uniform shape across all of them. |
 | `edit` | Does **not** shell out. Validate the fragment via `show`, then tell the user to run `worktask edit <id>` from their own shell. | The binary `syscall.Exec`s `$EDITOR`, which is unusable from an agent shell. |
 
 ## Reference slash command

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -21,7 +21,7 @@ worktask list [--all] [--closed] [--limit N]
 worktask show <fragment>
 worktask update <fragment> <new description>
 worktask append <fragment> <text>
-worktask complete <fragment>
+worktask close <fragment>
 worktask reopen <fragment>
 worktask edit <fragment>
 worktask research [<fragment>]
@@ -98,17 +98,17 @@ Adds text to the body of a task, preserving everything above it.
 $ worktask append milk remember the brand
 ```
 
-## `complete`
+## `close`
 
 Moves the file from `open/` to `closed/` via `os.Rename` and stamps `completed:` into the frontmatter.
 
 ```
-$ worktask complete milk
+$ worktask close milk
 ```
 
 ## `reopen`
 
-The inverse of `complete`: moves the file back to `open/` and clears the `completed:` field.
+The inverse of `close`: moves the file back to `open/` and clears the `completed:` field.
 
 ```
 $ worktask reopen milk

--- a/docs/src/content/docs/design.md
+++ b/docs/src/content/docs/design.md
@@ -15,7 +15,7 @@ By design, none of the following are in the tool. Add later only if a real need 
 - Multi-machine sync
 - Concurrent-write locking
 - A `delete` subcommand
-- Batch `complete --all`
+- Batch `close --all`
 - Shell completion
 - TUI or `fzf` picker
 

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -1,7 +1,7 @@
 ---
 title: Reference slash command
 description: Manage tasks via the worktask CLI
-argument-hint: <add|list|show|complete|reopen|update|append|edit|research|research-log> [args...]
+argument-hint: <add|list|show|close|reopen|update|append|edit|research|research-log> [args...]
 ---
 
 Manage tasks via the `worktask` CLI. Task state lives in per-task markdown files under the configured XDG data directory; this command never reads, parses, or rewrites `WORKING.md` or any task file directly. The CLI owns ID generation, slug generation, match resolution, and formatting.
@@ -15,7 +15,7 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 | `add <description>` | `worktask --format=json add "<description>"` |
 | `list` (also `--all`, `--closed`, `--limit N`) | `worktask --format=json list [flags]` |
 | `show <frag>` | `worktask --format=json show "<frag>"` |
-| `complete <frag>` | `worktask --format=json complete "<frag>"` |
+| `close <frag>` | `worktask --format=json close "<frag>"` |
 | `reopen <frag>` | `worktask --format=json reopen "<frag>"` |
 | `update <frag> <new description>` | `worktask --format=json update "<frag>" "<new description>"` |
 | `append <frag> <text>` | `worktask --format=json append "<frag>" "<text>"` |
@@ -38,7 +38,7 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 ## Success output
 
 - `list` and `show` return JSON. Render as a readable summary, or pass through.
-- `add`, `update`, `append`, `complete`, `reopen` print a single line (e.g. `added 1e3900e4`). Pass through.
+- `add`, `update`, `append`, `close`, `reopen` print a single line (e.g. `added 1e3900e4`). Pass through.
 
 ## `edit <frag>`
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -4,7 +4,7 @@
 //
 // Directory layout. Open tasks live as files under tasks_dir/open and
 // closed tasks under tasks_dir/closed. Filenames follow the
-// "<RFC3339-minute>_<id>[_<slug>].md" pattern. Completing a task moves
+// "<RFC3339-minute>_<id>[_<slug>].md" pattern. Closing a task moves
 // its file from open to closed; reopening moves it back. Both directories
 // are created lazily on first use.
 //
@@ -224,12 +224,12 @@ func (s *Store) Get(fragment string) (task.Task, []byte, error) {
 	return l.task, l.raw, nil
 }
 
-// Complete marks the open task identified by fragment as completed at
+// Close marks the open task identified by fragment as completed at
 // the current time, rewrites the file with the new frontmatter, and
 // moves it from open/ to closed/. Returns [*ErrNoMatch] or
 // [*ErrAmbiguous] when fragment does not resolve to exactly one open
 // task.
-func (s *Store) Complete(fragment string) (task.Task, error) {
+func (s *Store) Close(fragment string) (task.Task, error) {
 	l, err := s.resolve(fragment, []string{"open"})
 	if err != nil {
 		return task.Task{}, err

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -292,7 +292,7 @@ func TestGet_resolvesClosedTasks(t *testing.T) {
 	}
 }
 
-func TestComplete_movesFileFromOpenToClosedAndStampsCompleted(t *testing.T) {
+func TestClose_movesFileFromOpenToClosedAndStampsCompleted(t *testing.T) {
 	dir := t.TempDir()
 	s := New(dir)
 	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
@@ -304,9 +304,9 @@ func TestComplete_movesFileFromOpenToClosedAndStampsCompleted(t *testing.T) {
 	completedAt := time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC)
 	s.Now = func() time.Time { return completedAt }
 
-	got, err := s.Complete("abcdef12")
+	got, err := s.Close("abcdef12")
 	if err != nil {
-		t.Fatalf("Complete: %v", err)
+		t.Fatalf("Close: %v", err)
 	}
 	if got.ID != "abcdef12" {
 		t.Errorf("got.ID = %q; want %q", got.ID, "abcdef12")
@@ -340,8 +340,8 @@ func TestReopen_movesFileFromClosedToOpenAndClearsCompleted(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
-	if _, err := s.Complete("abcdef12"); err != nil {
-		t.Fatalf("Complete: %v", err)
+	if _, err := s.Close("abcdef12"); err != nil {
+		t.Fatalf("Close: %v", err)
 	}
 
 	got, err := s.Reopen("abcdef12")
@@ -371,7 +371,7 @@ func TestReopen_movesFileFromClosedToOpenAndClearsCompleted(t *testing.T) {
 	}
 }
 
-func TestComplete_fragmentMatchingOnlyClosedReturnsNoMatch(t *testing.T) {
+func TestClose_fragmentMatchingOnlyClosedReturnsNoMatch(t *testing.T) {
 	dir := t.TempDir()
 	s := New(dir)
 	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
@@ -380,13 +380,13 @@ func TestComplete_fragmentMatchingOnlyClosedReturnsNoMatch(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
-	if _, err := s.Complete("abcdef12"); err != nil {
-		t.Fatalf("first Complete: %v", err)
+	if _, err := s.Close("abcdef12"); err != nil {
+		t.Fatalf("first Close: %v", err)
 	}
 
-	_, err := s.Complete("abcdef12")
+	_, err := s.Close("abcdef12")
 	if err == nil {
-		t.Fatalf("Complete: expected error")
+		t.Fatalf("Close: expected error")
 	}
 	var nm *ErrNoMatch
 	if !errors.As(err, &nm) {
@@ -429,12 +429,12 @@ func TestList_filterClosedSortsByCompletedDescending(t *testing.T) {
 	}
 
 	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
-	if _, err := s.Complete("11111111"); err != nil {
-		t.Fatalf("Complete first: %v", err)
+	if _, err := s.Close("11111111"); err != nil {
+		t.Fatalf("Close first: %v", err)
 	}
 	s.Now = func() time.Time { return time.Date(2026, 4, 30, 10, 0, 0, 0, time.UTC) }
-	if _, err := s.Complete("22222222"); err != nil {
-		t.Fatalf("Complete second: %v", err)
+	if _, err := s.Close("22222222"); err != nil {
+		t.Fatalf("Close second: %v", err)
 	}
 
 	tasks, err := s.List(FilterClosed, 20)
@@ -464,8 +464,8 @@ func TestList_filterClosedHonorsLimit(t *testing.T) {
 			t.Fatalf("Add %d: %v", i, err)
 		}
 		s.Now = func() time.Time { return time.Date(2026, 4, 30, hour, 0, 0, 0, time.UTC) }
-		if _, err := s.Complete(id); err != nil {
-			t.Fatalf("Complete %d: %v", i, err)
+		if _, err := s.Close(id); err != nil {
+			t.Fatalf("Close %d: %v", i, err)
 		}
 	}
 
@@ -493,8 +493,8 @@ func TestList_filterAllReturnsOpenUncappedAndClosedCapped(t *testing.T) {
 			t.Fatalf("Add closed %d: %v", i, err)
 		}
 		s.Now = func() time.Time { return time.Date(2026, 4, 30, hour, 0, 0, 0, time.UTC) }
-		if _, err := s.Complete(id); err != nil {
-			t.Fatalf("Complete %d: %v", i, err)
+		if _, err := s.Close(id); err != nil {
+			t.Fatalf("Close %d: %v", i, err)
 		}
 	}
 	for i := 0; i < 3; i++ {


### PR DESCRIPTION
## Summary

- Rename `worktask complete <fragment>` → `worktask close <fragment>`. The verb now matches the inverse `reopen` and the `open/` ↔ `closed/` directory naming. The frontmatter `completed:` field and `task.Completed` describe the resulting *state* and stay as-is.
- Internal rename `Store.Complete` → `Store.Close`; `cmd/complete.go` → `cmd/close.go`; subcommand output is `closed <id>`.
- No hidden alias — the old verb errors out as `unknown command "complete"` so wrappers re-pin explicitly. Docs updated in the same PR (`cli.md`, `agentic.md`, `design.md`, slash-command example).

## Test plan

- [x] New `TestCloseCmd_movesOpenTaskToClosedAndPrintsClosedID` exercises the new verb end-to-end via `rootCmd`.
- [x] New `TestCompleteCmd_isRemoved` enforces no-alias by asserting `unknown command "complete"`.
- [x] `internal/store` tests renamed and re-pointed at `Store.Close`; existing assertions about file moves, `completed:` stamping, and `Reopen` still pass.
- [x] `just ci` (`fmt-check`, `vet`, `test`) green.
- [x] `golangci-lint run` green.

Closes #23

🤖 Generated with [Claude Code](https://claude.com/claude-code)