### PR TITLE
ci(release): goreleaser config + tag-driven release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,38 @@
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Tag to release (must already exist)'
+        required: true
+
+jobs:
+  goreleaser:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ inputs.tag || github.ref }}
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.26.x'
+          cache: true
+
+      - name: Run GoReleaser
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          distribution: goreleaser
+          version: '~> v2'
+          args: release --clean
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 .scratch/
 bin/
+dist/

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,0 +1,50 @@
+version: 2
+
+project_name: worktask
+
+before:
+  hooks:
+    - go mod tidy
+
+builds:
+  - id: worktask
+    main: .
+    binary: worktask
+    env:
+      - CGO_ENABLED=0
+    goos:
+      - linux
+      - darwin
+    goarch:
+      - amd64
+      - arm64
+    flags:
+      - -trimpath
+    ldflags:
+      - -s -w
+      - -X github.com/jvcorredor/worktask/internal/version.Version={{ .Version }}
+      - -X github.com/jvcorredor/worktask/internal/version.Commit={{ .FullCommit }}
+      - -X github.com/jvcorredor/worktask/internal/version.Date={{ .CommitDate }}
+
+archives:
+  - id: worktask
+    ids:
+      - worktask
+    formats: [tar.gz]
+    name_template: worktask_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    files:
+      - LICENSE
+
+checksum:
+  name_template: checksums.txt
+  algorithm: sha256
+
+snapshot:
+  version_template: "{{ incpatch .Version }}-snapshot"
+
+release:
+  draft: false
+  prerelease: auto
+
+changelog:
+  disable: true

--- a/justfile
+++ b/justfile
@@ -40,3 +40,7 @@ lint:
 
 # Run the full local CI gate (fmt-check, vet, test) in workflow order
 ci: fmt-check vet test
+
+# Build a local snapshot release with goreleaser into ./dist (no publish)
+release-snapshot:
+    goreleaser release --snapshot --clean


### PR DESCRIPTION
## Summary

- Adds `.goreleaser.yaml` building `linux/{amd64,arm64}` and `darwin/{amd64,arm64}`. CGO off, `-trimpath` + `-s -w`, ldflags injecting `internal/version.{Version,Commit,Date}` (the actual landing zone from #29 — the issue's `main.*` nomenclature predates `internal/version`).
- Adds `.github/workflows/release.yml` running goreleaser on tag push / `workflow_dispatch` with default `GITHUB_TOKEN` at `contents: write`. `fetch-depth: 0` so goreleaser sees tags and commit metadata.
- Adds a `release-snapshot` justfile recipe wrapping `goreleaser release --snapshot --clean`. Gitignores `dist/`.

Archive layout matches the spec: `worktask_{Version}_{Os}_{Arch}.tar.gz` containing the `worktask` binary at the root plus `LICENSE`. SHA256 `checksums.txt` is published alongside.

Closes #30 once a maintainer-pushed throwaway tag has demonstrated end-to-end (acceptance criterion #8).

## Test plan

- [x] `goreleaser check` passes.
- [x] `goreleaser release --snapshot --clean` succeeds locally and writes four `worktask_0.0.1-snapshot_{os}_{arch}.tar.gz` archives + `checksums.txt` to `dist/`.
- [x] Each archive contains `worktask` + `LICENSE` at its root (verified for `darwin_arm64`).
- [x] Extracted snapshot binary reports `worktask version 0.0.1-snapshot` and `worktask version --format json` returns `source: "ldflags"` with the embedded version, commit, and ISO-8601 date.
- [x] `darwin/arm64` Mach-O has `LC_CODE_SIGNATURE` (Go linker ad-hoc signing kicks in even on a Linux runner — no extra plumbing required).
- [x] `just ci` is green.
- [ ] Maintainer end-to-end: push a `v0.0.1-test` tag and confirm the resulting GitHub Release has the four archives + `checksums.txt`, and that the embedded version reported by the produced binary matches the tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)