### PR TITLE
ci(release): semantic-release on push to main, cuts v0.1.0 on merge

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -2,37 +2,45 @@ name: Release
 
 on:
   push:
-    tags:
-      - 'v*'
-  workflow_dispatch:
-    inputs:
-      tag:
-        description: 'Tag to release (must already exist)'
-        required: true
+    branches:
+      - main
+
+# One release at a time. cancel-in-progress: false so an in-flight
+# upload is queued behind, not aborted mid-flight.
+concurrency:
+  group: release
+  cancel-in-progress: false
 
 jobs:
-  goreleaser:
+  release:
     runs-on: ubuntu-latest
     permissions:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         with:
           fetch-depth: 0
-          ref: ${{ inputs.tag || github.ref }}
 
       - name: Set up Go
-        uses: actions/setup-go@v5
+        uses: actions/setup-go@v6
         with:
           go-version: '1.26.x'
           cache: true
 
-      - name: Run GoReleaser
-        uses: goreleaser/goreleaser-action@v6
+      # semantic-release reads conventional commits since the last
+      # tag, computes the next version, creates the GitHub release +
+      # tag via the API, then invokes goreleaser as a hook to build,
+      # archive, and upload binaries onto that release in the same
+      # checkout. allow-initial-development-versions keeps the
+      # project on the 0.x track and treats breaking changes as
+      # minor bumps until a 1.0.0 release exists; once it does, the
+      # flag is silently ignored and breaking changes resume bumping
+      # major.
+      - name: Run semantic-release
+        uses: go-semantic-release/action@v1
         with:
-          distribution: goreleaser
-          version: '~> v2'
-          args: release --clean
+          allow-initial-development-versions: true
+          hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -24,7 +24,7 @@ builds:
       - -s -w
       - -X github.com/jvcorredor/worktask/internal/version.Version={{ .Version }}
       - -X github.com/jvcorredor/worktask/internal/version.Commit={{ .FullCommit }}
-      - -X github.com/jvcorredor/worktask/internal/version.Date={{ .CommitDate }}
+      - -X github.com/jvcorredor/worktask/internal/version.Date={{ .Date }}
 
 archives:
   - id: worktask


### PR DESCRIPTION
## Summary

- Replaces the tag-driven `Release` workflow with a single push-to-main job that runs `go-semantic-release` (computes the next version from conventional commits, creates the GitHub release + tag via the API) and invokes `goreleaser` as a hook in the same checkout to upload binaries onto that release.
- `--allow-initial-development-versions` keeps the project on the 0.x track and treats breaking changes as minor bumps; once a 1.0.0 release exists the flag is silently ignored and breaking changes auto-resume bumping major. The analyzer's defaults already give us `feat → minor`, `fix → patch`, and `chore / docs / refactor / test / ci / build → no release`, so no `.semrelrc` is needed.
- `concurrency: { group: release, cancel-in-progress: false }` queues overlapping runs instead of aborting an in-flight upload mid-flight.
- Updates `.goreleaser.yaml` ldflags from `{{ .CommitDate }}` to `{{ .Date }}`: `hooks-goreleaser` skips goreleaser's git pipe and does not populate `CommitDate`, so the previous template would have rendered the zero time once invoked from the hook.

## Why no `.semrelrc`

The PRD's "(or equivalent config)" was specifically because `--allow-initial-development-versions` is the lever the analyzer exposes for "treat breaking changes as minor while major is 0," and it is a CLI flag, not a `.semrelrc` field. The default `commit-analyzer-cz` plugin's release rules already match the rest of the spec, so adding an empty `.semrelrc` would be noise.

## What happens on merge

- semantic-release sees no prior tags, computes `v0.1.0` (the flag's bootstrap version), creates the GitHub release + tag, then runs goreleaser to attach the four-target archives + `checksums.txt` from #30.
- The release notes for v0.1.0 will summarise every conventional commit since project inception — slightly archaeological. The maintainer is expected to clean these up by hand on the Releases page after the fact (called out in #31).

## Test plan

- [ ] After merging, confirm the `Release` workflow runs once and produces a `v0.1.0` GitHub release with the four `worktask_v0.1.0_<os>_<arch>.tar.gz` archives + `checksums.txt`.
- [ ] Confirm `worktask version` from the released `linux_amd64` binary reports `v0.1.0` with a non-zero `built` date.
- [ ] Land a follow-up `feat:` commit on main and confirm it cuts `v0.2.0`; a `fix:` cuts `v0.1.1`; a `chore:` cuts no release.
- [ ] Tidy up the v0.1.0 release notes on the Releases page (one-time, see above).

Closes: #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)