### PR TITLE
fix(release): use goreleaser v2.3.2-compatible archive schema

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -27,10 +27,13 @@ builds:
       - -X github.com/jvcorredor/worktask/internal/version.Date={{ .Date }}
 
 archives:
+  # `format:` (singular) and the absence of `ids:` are required for
+  # compatibility with the goreleaser library version pinned by
+  # hooks-goreleaser (currently goreleaser v2.3.2). The newer
+  # `formats: [tar.gz]` and `ids: [worktask]` schema fields are
+  # rejected by that version's unmarshaller.
   - id: worktask
-    ids:
-      - worktask
-    formats: [tar.gz]
+    format: tar.gz
     name_template: worktask_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:
       - LICENSE


### PR DESCRIPTION
## What broke

The first run of #49 created the v0.1.0 GitHub release but the goreleaser hook failed to upload archives:

\`\`\`
yaml: unmarshal errors:
  line 31: field ids not found in type config.Archive
  line 33: field formats not found in type config.Archive
\`\`\`

\`hooks-goreleaser\` vendors goreleaser v2.3.2 (per its \`go.mod\`), which predates the \`ids:\` and \`formats:\` plural schema fields. The existing \`.goreleaser.yaml\` was written for a more recent goreleaser, hence the mismatch.

## Fix

- \`formats: [tar.gz]\` → \`format: tar.gz\` (singular, supported by v2.3.2).
- Drop \`ids: [worktask]\` — we have one build, the default already includes it. (The older equivalent \`builds:\` would also work but adds nothing.)

## Required maintainer step before merging

The empty v0.1.0 release and tag must be deleted first so semantic-release re-cuts v0.1.0 with archives on merge:

\`\`\`
gh release delete v0.1.0 --repo jvcorredor/worktask --cleanup-tag --yes
\`\`\`

If left in place, semantic-release sees v0.1.0 already exists, this \`fix:\` cuts v0.1.1, and v0.1.0 stays orphaned (no archives forever).

## Test plan

- [ ] Maintainer deletes empty v0.1.0 release+tag.
- [ ] Merge cuts v0.1.0 with the four \`worktask_v0.1.0_<os>_<arch>.tar.gz\` archives + \`checksums.txt\`.
- [ ] \`worktask version\` from the linux_amd64 binary reports v0.1.0 with a non-zero \`built\` date.

Refs: #31

🤖 Generated with [Claude Code](https://claude.com/claude-code)