### PR TITLE
feat(cli): add path field to `worktask show --format=json`

### DIFF
--- a/cmd/research-log.go
+++ b/cmd/research-log.go
@@ -22,7 +22,7 @@ var researchLogCmd = &cobra.Command{
 		}
 		s := store.New(cfg.TasksDir)
 
-		t, _, err := s.Get(fragment)
+		t, _, _, err := s.Get(fragment)
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -63,7 +63,7 @@ func init() {
 }
 
 func runSingleResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, fragment string) error {
-	t, _, err := s.Get(fragment)
+	t, _, _, err := s.Get(fragment)
 	if err != nil {
 		return handleResolveError(cmd, s, fragment, err)
 	}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -22,14 +22,14 @@ var showCmd = &cobra.Command{
 			return err
 		}
 
-		t, raw, err := s.Get(fragment)
+		t, raw, path, err := s.Get(fragment)
 		if err != nil {
 			return handleResolveError(cmd, s, fragment, err)
 		}
 
 		switch format {
 		case formatJSON:
-			data, err := render.JSONShow(t)
+			data, err := render.JSONShow(t, path)
 			if err != nil {
 				return err
 			}

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -2,6 +2,7 @@ package cmd
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"os"
 	"path/filepath"
@@ -184,5 +185,68 @@ func TestShowCmd_humanNoMatchPipeModeIsPlain(t *testing.T) {
 	}
 	if bytes.ContainsRune(stderr.Bytes(), '\x1b') {
 		t.Errorf("no-match pipe-mode stderr must not contain ANSI escapes, got %q", stderr.String())
+	}
+}
+
+// TestShowCmd_jsonIncludesAbsolutePath asserts that `worktask show --format=json`
+// emits a top-level `path` field whose value is the absolute filesystem path
+// of the resolved task file. The test seeds an open-task file on disk, runs
+// `show <id> --format=json`, and parses the stdout JSON to compare `path`
+// against the path the test wrote to.
+func TestShowCmd_jsonIncludesAbsolutePath(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	tk := task.Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Body:    "buy milk\nremember the brand\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("task.Encode: %v", err)
+	}
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	wantPath := filepath.Join(openDir, "abcdef12-buy-milk.md")
+	if err := os.WriteFile(wantPath, raw, 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+
+	prevFormat := format
+	format = formatJSON
+	t.Cleanup(func() { format = prevFormat })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"show", "abcdef12"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute show: %v (stderr=%s)", err, stderr.String())
+	}
+
+	var got struct {
+		Path string `json:"path"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("parse JSON: %v\nstdout=%s", err, stdout.String())
+	}
+	if got.Path == "" {
+		t.Fatalf("expected `path` field in JSON output, got %s", stdout.String())
+	}
+	if !filepath.IsAbs(got.Path) {
+		t.Errorf("`path` = %q; want an absolute path", got.Path)
+	}
+	if got.Path != wantPath {
+		t.Errorf("`path` = %q; want %q", got.Path, wantPath)
 	}
 }

--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -24,7 +24,7 @@ Pass `--format=json` to any subcommand to get machine-readable output. The schem
 
 `completed` is omitted on open tasks.
 
-`show` returns the same fields plus `body` (the full body string after the first description line).
+`show` returns the same fields plus `body` (the full body string after the first description line) and `path` (the absolute, cleaned filesystem path of the task file; symlinks in the configured tasks directory are preserved verbatim).
 
 Golden fixtures for the JSON schema live in `internal/render/testdata/` in the repo and are the authoritative reference for any wire-format edge cases.
 

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -75,11 +75,12 @@ In `--format=human`, the rendering is TTY-aware:
 - When stdout is a terminal, the body is rendered as styled Markdown (headings, code blocks, lists, tables) via [glamour](https://github.com/charmbracelet/glamour) using its `auto` style, wrapped at the terminal width capped at 120 columns. A subdued one-line metadata strip — `{id} · {YYYY-MM-DD created} · {open|closed}` — is printed above the body. Operational fields like `last_researched` and `last_research_log` are intentionally omitted; agents can still get them via `--format=json`. `NO_COLOR` disables colour while preserving layout.
 - When stdout is piped, redirected, or running in a non-TTY environment (CI, scripts), the raw markdown file (frontmatter included) is written verbatim, preserving any workflow that pipes `show` output into an editor or other tooling.
 
-In `--format=json`, it prints a JSON object with `id`, `created`, `description`, `body`, and (if closed) `completed`. JSON output is unchanged by TTY detection.
+In `--format=json`, it prints a JSON object with `id`, `created`, `description`, `body`, `path`, and (if closed) `completed`. `path` is the absolute, cleaned filesystem path of the task file; symlinks in the configured tasks directory are preserved verbatim. JSON output is unchanged by TTY detection.
 
 ```
 $ worktask show milk
 $ worktask --format=json show abcdef12
+$ worktask --format=json show abcdef12 | jq -r .path  # the file on disk
 ```
 
 ## `update`

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -13,7 +13,9 @@
 //	]
 //
 // JSON show schema (stable): same fields as the list element plus "body"
-// (full task body, including the canonical first line as "description").
+// (full task body, including the canonical first line as "description")
+// and "path" (absolute, cleaned filesystem path of the task file;
+// symlinks in the configured tasks directory are preserved verbatim).
 //
 // JSON research-run schema (stable): per-task summary line emitted on stdout
 // when `worktask research <hash>` completes.
@@ -50,6 +52,7 @@ type jsonTask struct {
 type jsonShowTask struct {
 	jsonTask
 	Body string `json:"body"`
+	Path string `json:"path"`
 }
 
 type jsonMatch struct {
@@ -246,9 +249,10 @@ func marshalLine(v any) ([]byte, error) {
 }
 
 // JSONShow renders a single task in the show schema described in the
-// package documentation: the list-element fields plus the full body.
-func JSONShow(t task.Task) ([]byte, error) {
-	return marshalIndent(jsonShowTask{jsonTask: toJSONTask(t), Body: t.Body})
+// package documentation: the list-element fields plus the full body
+// and the absolute filesystem path of the task file.
+func JSONShow(t task.Task, path string) ([]byte, error) {
+	return marshalIndent(jsonShowTask{jsonTask: toJSONTask(t), Body: t.Body, Path: path})
 }
 
 // JSONList renders tasks as the stable list-element schema described

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -433,7 +433,7 @@ func TestJSONShow_matchesSnapshot(t *testing.T) {
 		Body:    "buy milk\nremember the brand\n",
 	}
 
-	got, err := JSONShow(tk)
+	got, err := JSONShow(tk, "/tasks/open/2026-04-29T11-30_abcdef12_buy-milk.md")
 	if err != nil {
 		t.Fatalf("JSONShow: %v", err)
 	}

--- a/internal/render/testdata/show.json
+++ b/internal/render/testdata/show.json
@@ -2,5 +2,6 @@
   "id": "abcdef12",
   "created": "2026-04-29T11:30:00Z",
   "description": "buy milk",
-  "body": "buy milk\nremember the brand\n"
+  "body": "buy milk\nremember the brand\n",
+  "path": "/tasks/open/2026-04-29T11-30_abcdef12_buy-milk.md"
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -214,14 +214,15 @@ func (e *ErrNoMatch) Error() string {
 }
 
 // Get resolves fragment against both open and closed tasks and returns
-// the matching [task.Task] together with the raw bytes of its file.
-// Returns [*ErrNoMatch] or [*ErrAmbiguous] when resolution fails.
-func (s *Store) Get(fragment string) (task.Task, []byte, error) {
+// the matching [task.Task], the raw bytes of its file, and the
+// absolute, cleaned path of the file (matching [Store.Path]). Returns
+// [*ErrNoMatch] or [*ErrAmbiguous] when resolution fails.
+func (s *Store) Get(fragment string) (task.Task, []byte, string, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
-		return task.Task{}, nil, err
+		return task.Task{}, nil, "", err
 	}
-	return l.task, l.raw, nil
+	return l.task, l.raw, l.path, nil
 }
 
 // Close marks the open task identified by fragment as completed at
@@ -333,9 +334,12 @@ func (s *Store) SetResearchMeta(fragment string, lastResearched time.Time, logPa
 	return t, nil
 }
 
-// Path returns the absolute path of the task file identified by
-// fragment. The task may be open or closed. Returns [*ErrNoMatch] or
-// [*ErrAmbiguous] when fragment does not resolve.
+// Path returns the absolute, cleaned path of the task file identified
+// by fragment. The path is absolute even when [Store.TasksDir] is
+// configured as a relative path. Symlinks in TasksDir are preserved
+// verbatim — no [filepath.EvalSymlinks] resolution. The task may be
+// open or closed. Returns [*ErrNoMatch] or [*ErrAmbiguous] when
+// fragment does not resolve.
 func (s *Store) Path(fragment string) (string, error) {
 	l, err := s.resolve(fragment, []string{"open", "closed"})
 	if err != nil {
@@ -418,6 +422,11 @@ func (s *Store) loadAll(subdirs []string) ([]loaded, error) {
 				continue
 			}
 			path := filepath.Join(dir, e.Name())
+			abs, err := filepath.Abs(path)
+			if err != nil {
+				return nil, fmt.Errorf("store: abs %s: %w", path, err)
+			}
+			path = abs
 			data, err := os.ReadFile(path)
 			if err != nil {
 				return nil, fmt.Errorf("store: read %s: %w", path, err)

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -101,7 +101,7 @@ func TestGet_exactID(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	got, raw, err := s.Get("abcdef12")
+	got, raw, gotPath, err := s.Get("abcdef12")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -115,6 +115,13 @@ func TestGet_exactID(t *testing.T) {
 	if string(raw) != wantRaw {
 		t.Errorf("raw bytes:\n--- got ---\n%s\n--- want ---\n%s", raw, wantRaw)
 	}
+	wantPath, err := s.Path("abcdef12")
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	if gotPath != wantPath {
+		t.Errorf("Get path = %q; want %q (must match Store.Path for the same fragment)", gotPath, wantPath)
+	}
 }
 
 func TestGet_idPrefix(t *testing.T) {
@@ -126,7 +133,7 @@ func TestGet_idPrefix(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	got, _, err := s.Get("abcd")
+	got, _, _, err := s.Get("abcd")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -144,7 +151,7 @@ func TestGet_descriptionExactCI(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	got, _, err := s.Get("buy milk")
+	got, _, _, err := s.Get("buy milk")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -162,7 +169,7 @@ func TestGet_descriptionSubstring(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	got, _, err := s.Get("MILK")
+	got, _, _, err := s.Get("MILK")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -185,7 +192,7 @@ func TestGet_idExactShortCircuits(t *testing.T) {
 		t.Fatalf("Add B: %v", err)
 	}
 
-	got, _, err := s.Get("abcdef12")
+	got, _, _, err := s.Get("abcdef12")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -208,7 +215,7 @@ func TestGet_ambiguousReturnsTypedErrorWithCandidates(t *testing.T) {
 		t.Fatalf("Add B: %v", err)
 	}
 
-	_, _, err := s.Get("milk")
+	_, _, _, err := s.Get("milk")
 	if err == nil {
 		t.Fatalf("Get: expected error")
 	}
@@ -243,7 +250,7 @@ func TestGet_zeroMatchReturnsTypedError(t *testing.T) {
 		t.Fatalf("Add: %v", err)
 	}
 
-	_, _, err := s.Get("nonexistent-zzz")
+	_, _, _, err := s.Get("nonexistent-zzz")
 	if err == nil {
 		t.Fatalf("Get: expected error")
 	}
@@ -280,7 +287,7 @@ func TestGet_resolvesClosedTasks(t *testing.T) {
 	}
 
 	s := New(dir)
-	got, _, err := s.Get("deadbeef")
+	got, _, _, err := s.Get("deadbeef")
 	if err != nil {
 		t.Fatalf("Get: %v", err)
 	}
@@ -743,6 +750,42 @@ func TestPath_returnsResolvedFilePath(t *testing.T) {
 	want := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_buy-milk.md")
 	if got != want {
 		t.Errorf("Path = %q; want %q", got, want)
+	}
+}
+
+// TestPath_returnsAbsolutePathEvenWhenTasksDirIsRelative pins the
+// docstring contract on Store.Path: callers receive a path they can use
+// from any working directory, regardless of how the store was
+// configured. We chdir into a tempdir, point the store at a relative
+// "tasks" sibling, and assert the returned path is absolute.
+func TestPath_returnsAbsolutePathEvenWhenTasksDirIsRelative(t *testing.T) {
+	root := t.TempDir()
+	tasksAbs := filepath.Join(root, "tasks")
+	if err := os.MkdirAll(tasksAbs, 0o755); err != nil {
+		t.Fatalf("MkdirAll: %v", err)
+	}
+	prev, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("Getwd: %v", err)
+	}
+	if err := os.Chdir(root); err != nil {
+		t.Fatalf("Chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(prev) })
+
+	s := New("tasks")
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.Path("abcdef12")
+	if err != nil {
+		t.Fatalf("Path: %v", err)
+	}
+	if !filepath.IsAbs(got) {
+		t.Errorf("Path = %q; want an absolute path (TasksDir was relative)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

- `worktask show <fragment> --format=json` returns the absolute filesystem path of the resolved task file as a top-level `path` field. Existing fields and the list / error-envelope schemas are unchanged.
- `Store.loadAll` canonicalises paths to absolute at load time, so `Store.Path` finally honours its docstring and `Store.Get` returns the same path with no second directory scan.
- Same-PR docs updates per CLAUDE.md: `cli.md` show section, agentic page show schema, and the `internal/render` package doc. The reference slash-command file is unchanged — the schema addition is purely additive.

Closes: #56

## Test plan

- [x] `just ci` (fmt-check, vet, tests across all packages)
- [x] `golangci-lint run ./...`
- [x] New `internal/store` test pins `Store.Path` returning an absolute path under a relative `TasksDir`
- [x] Existing `Store.Get` test extended to assert the new path return value matches `Store.Path`
- [x] `internal/render/testdata/show.json` golden updated; `TestJSONShow_matchesSnapshot` passes
- [x] New `cmd/show_test.go` integration test runs `worktask --format=json show <id>` and asserts `path` is absolute and matches the file on disk
- [x] Existing pipe-mode `HumanShow` regression tests still pass byte-for-byte
- [x] End-to-end: built the binary against a temp `XDG_DATA_HOME`, ran `add` then `--format=json show`, confirmed `path` matches the on-disk file