### PR TITLE
feat(install): POSIX install.sh + install/release docs

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -6,6 +6,7 @@ on:
       - main
     paths:
       - docs/src/**
+      - docs/public/**
       - docs/astro.config.mjs
       - docs/package.json
       - docs/yarn.lock

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -31,3 +31,6 @@ jobs:
 
       - name: Test
         run: go test ./...
+
+      - name: Test install.sh
+        run: sh tests/install/run.sh

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -16,7 +16,7 @@ This repo uses `just` as a task runner; install it once with `brew install just`
 
 Run `just --list` to discover the available recipes — every recipe carries a one-line description.
 
-Run `just ci` before opening a Go PR; it runs `fmt-check`, `vet`, and `test` locally so failures surface before pushing.
+Run `just ci` before opening a Go PR; it runs `fmt-check`, `vet`, `test`, and `test-install` locally so failures surface before pushing.
 
 ## Go source-level docs
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,7 @@
 
 [![Go Reference](https://pkg.go.dev/badge/github.com/jvcorredor/worktask.svg)](https://pkg.go.dev/github.com/jvcorredor/worktask)
 [![Go Report Card](https://goreportcard.com/badge/github.com/jvcorredor/worktask)](https://goreportcard.com/report/github.com/jvcorredor/worktask)
+[![Release](https://img.shields.io/github/v/release/jvcorredor/worktask?label=release)](https://github.com/jvcorredor/worktask/releases)
 [![Docs](https://img.shields.io/badge/docs-jvcorredor.github.io%2Fworktask-blue)](https://jvcorredor.github.io/worktask/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
@@ -10,10 +11,11 @@ A Go CLI for task management designed primarily for LLM-agent consumption (Claud
 ## Install
 
 ```
-go install github.com/jvcorredor/worktask@latest
+curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh    # pre-built binary
+go install github.com/jvcorredor/worktask@latest                    # from source
 ```
 
-The binary lands in `$GOBIN` as `worktask`. Alias to `wt` if you want a shorter handle.
+The binary lands in `$HOME/.local/bin` (or `$GOBIN` for `go install`) as `worktask`. See the [install reference](https://jvcorredor.github.io/worktask/install/) for env-var overrides and `$PATH` setup.
 
 ## Documentation
 

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -21,6 +21,7 @@ export default defineConfig({
           label: 'Getting started',
           items: [
             { label: 'Index', slug: 'index' },
+            { label: 'Install', slug: 'install' },
             { label: 'CLI reference', slug: 'cli' },
           ],
         },
@@ -30,6 +31,7 @@ export default defineConfig({
             { label: 'File & storage format', slug: 'storage' },
             { label: 'Configuration', slug: 'config' },
             { label: 'Agentic usage', slug: 'agentic' },
+            { label: 'Releases', slug: 'releases' },
           ],
         },
         {

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,0 +1,119 @@
+#!/bin/sh
+# worktask installer — POSIX, no bashisms.
+#
+# Usage:  curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+#
+# Env vars:
+#   INSTALL_DIR   destination directory (default: $HOME/.local/bin)
+#   VERSION       release tag without leading "v" (default: latest)
+
+set -eu
+
+REPO='jvcorredor/worktask'
+RELEASES_BASE="https://github.com/${REPO}/releases/download"
+LATEST_API="https://api.github.com/repos/${REPO}/releases/latest"
+
+INSTALL_DIR="${INSTALL_DIR:-$HOME/.local/bin}"
+
+die() {
+    printf 'install.sh: %s\n' "$*" >&2
+    exit 1
+}
+
+resolve_version() {
+    if [ -n "${VERSION:-}" ]; then
+        printf '%s\n' "${VERSION#v}"
+        return
+    fi
+    tag=$(curl -fsSL "$LATEST_API" \
+        | sed -n 's/.*"tag_name"[[:space:]]*:[[:space:]]*"\([^"]*\)".*/\1/p' \
+        | head -n1)
+    [ -n "$tag" ] || die "could not resolve latest release tag from $LATEST_API"
+    printf '%s\n' "${tag#v}"
+}
+
+detect_platform() {
+    kernel=$(uname -s)
+    machine=$(uname -m)
+    case "$kernel" in
+        Linux) os=linux ;;
+        Darwin) os=darwin ;;
+        *) die "unsupported OS: $kernel" ;;
+    esac
+    case "$machine" in
+        x86_64|amd64) arch=amd64 ;;
+        arm64|aarch64) arch=arm64 ;;
+        *) die "unsupported architecture: $machine" ;;
+    esac
+    printf '%s_%s\n' "$os" "$arch"
+}
+
+sha256_hash() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+installed_version() {
+    bin="$1"
+    [ -x "$bin" ] || return 0
+    "$bin" version 2>/dev/null | awk 'NR==1 {print $2}' | sed 's/^v//'
+}
+
+print_path_hint_if_needed() {
+    case ":$PATH:" in
+        *":$INSTALL_DIR:"*) return 0 ;;
+    esac
+    case "$(basename "${SHELL:-/bin/sh}")" in
+        fish)
+            printf '%s is not on $PATH. Add it with:\n    fish_add_path %s\n' \
+                "$INSTALL_DIR" "$INSTALL_DIR" ;;
+        *)
+            printf '%s is not on $PATH. Add it with:\n    export PATH="%s:$PATH"\n' \
+                "$INSTALL_DIR" "$INSTALL_DIR" ;;
+    esac
+}
+
+main() {
+    version=$(resolve_version)
+    platform=$(detect_platform)
+    tag="v${version}"
+    tarball="worktask_${version}_${platform}.tar.gz"
+    tarball_url="${RELEASES_BASE}/${tag}/${tarball}"
+    checksums_url="${RELEASES_BASE}/${tag}/checksums.txt"
+
+    install_path="$INSTALL_DIR/worktask"
+    existing=$(installed_version "$install_path")
+
+    workdir=$(mktemp -d "${TMPDIR:-/tmp}/worktask-install.XXXXXX")
+    trap 'rm -rf "$workdir"' EXIT
+
+    printf 'Downloading %s\n' "$tarball"
+    curl -fsSL "$tarball_url" -o "$workdir/$tarball" \
+        || die "failed to download $tarball_url"
+    curl -fsSL "$checksums_url" -o "$workdir/checksums.txt" \
+        || die "failed to download $checksums_url"
+
+    expected=$(awk -v f="$tarball" '$2 == f { print $1; exit }' "$workdir/checksums.txt")
+    [ -n "$expected" ] || die "no checksum for $tarball in checksums.txt"
+    actual=$(sha256_hash "$workdir/$tarball")
+    [ "$expected" = "$actual" ] || die "checksum mismatch for $tarball: expected $expected, got $actual"
+
+    tar -xzf "$workdir/$tarball" -C "$workdir" worktask \
+        || die "failed to extract worktask from $tarball"
+
+    mkdir -p "$INSTALL_DIR"
+    if [ -n "$existing" ] && [ "$existing" != "$version" ]; then
+        printf 'Upgrading worktask from %s to %s\n' "$existing" "$version"
+    fi
+    mv "$workdir/worktask" "$install_path"
+    chmod +x "$install_path"
+
+    printf 'Installed worktask %s to %s\n' "$version" "$install_path"
+
+    print_path_hint_if_needed
+}
+
+main "$@"

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -9,6 +9,16 @@ Match resolution, ID generation, slug generation, and formatting all live in the
 
 ## Install
 
+Pre-built binary (no Go toolchain required):
+
+```
+curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+```
+
+Installs the latest release to `$HOME/.local/bin/worktask`. Override the destination with `INSTALL_DIR=/usr/local/bin` or pin the release with `VERSION=0.2.0`. Full reference and verification details live on the [Install](./install.md) page.
+
+From source (requires Go):
+
 ```
 go install github.com/jvcorredor/worktask@latest
 ```
@@ -17,8 +27,10 @@ The binary lands in `$GOBIN` as `worktask`. Alias to `wt` if you want a shorter 
 
 ## Where to go next
 
+- [Install](./install.md) — both install methods, env-var overrides, `$PATH` setup, checksum verification, macOS quarantine note.
 - [CLI reference](./cli.md) — every subcommand, flags, examples, and match-resolution behavior.
 - [File & storage format](./storage.md) — data directory layout and the on-disk shape of a task file.
 - [Configuration](./config.md) — `tasks_dir`, `editor`, XDG paths, and resolution order.
 - [Agentic usage](./agentic.md) — JSON schema, error envelopes, and the slash-command dispatch pattern.
+- [Releases](./releases.md) — Conventional Commits, pre-1.0 versioning policy, link to the GitHub Releases page.
 - [Design notes](./design.md) — out-of-scope items, internal package layout, and the migration tool.

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -1,0 +1,58 @@
+---
+title: Install
+description: Install worktask from a pre-built binary or from source, with environment-variable overrides, $PATH setup, and checksum verification.
+---
+
+worktask supports two install methods: a pre-built binary served from this docs site (no Go toolchain required), and `go install` from source.
+
+## Pre-built binary
+
+```
+curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+```
+
+The script downloads the platform-appropriate tarball and `checksums.txt` from the matching [GitHub Release](https://github.com/jvcorredor/worktask/releases), verifies the SHA256 of the tarball against the manifest, and extracts the `worktask` binary into the install directory. It does not edit any shell rc files.
+
+### Environment-variable overrides
+
+| Variable      | Default                  | Notes                                                                        |
+|---------------|--------------------------|------------------------------------------------------------------------------|
+| `INSTALL_DIR` | `$HOME/.local/bin`       | Destination directory. Use `/usr/local/bin` for a system-wide install.       |
+| `VERSION`     | latest GitHub release    | Pin to a specific release tag, e.g. `VERSION=0.2.0` (leading `v` optional).  |
+
+```
+INSTALL_DIR=/usr/local/bin curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sudo sh
+VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+```
+
+### Supported platforms
+
+`linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`. Other platforms abort with a clear error; build from source instead.
+
+### `$PATH` setup
+
+If the install directory is not on your `$PATH`, the script prints a one-line snippet you can paste into your shell config — `export PATH="$HOME/.local/bin:$PATH"` for bash/zsh/sh, `fish_add_path $HOME/.local/bin` for fish. The script never edits rc files itself.
+
+### Checksum verification
+
+The script downloads `checksums.txt` from the same release and compares the SHA256 of the tarball against the entry for the platform-specific filename. A mismatch aborts with a non-zero exit and a clear error; nothing is installed in that case.
+
+### Re-running the script
+
+If a `worktask` binary already lives at the destination, the script reads its version with `worktask version` and prints `Upgrading worktask from X to Y` when the resolved version differs.
+
+### macOS quarantine note
+
+Tarballs downloaded through a browser get the `com.apple.quarantine` extended attribute, which makes Gatekeeper block the binary on first run. The install script downloads via `curl` and is unaffected. If you fetched the tarball manually instead, clear the attribute once before running:
+
+```
+xattr -dr com.apple.quarantine ./worktask
+```
+
+## From source (`go install`)
+
+```
+go install github.com/jvcorredor/worktask@latest
+```
+
+Requires a Go toolchain. The binary lands in `$GOBIN` (or `$GOPATH/bin`) as `worktask`. Pin a specific version with `@v0.2.0`. Module-mode `go install` does the same SHA verification as any other Go module download.

--- a/docs/src/content/docs/releases.md
+++ b/docs/src/content/docs/releases.md
@@ -1,0 +1,39 @@
+---
+title: Releases
+description: How worktask versions and ships releases — Conventional Commits, pre-1.0 policy, and where to find the artifacts.
+---
+
+Release notes, source archives, and platform-specific tarballs for every version live on the [GitHub Releases page](https://github.com/jvcorredor/worktask/releases). The latest release is also what `curl ... | sh` installs by default; see [Install](./install.md).
+
+## Conventional Commits
+
+Every commit on `main` follows [Conventional Commits](https://www.conventionalcommits.org/). The release pipeline runs on every push to `main` and decides whether to cut a tag based on the commit type:
+
+| Commit type                                         | Effect on version          |
+|-----------------------------------------------------|----------------------------|
+| `feat:`                                             | bumps minor                |
+| `fix:`                                              | bumps patch                |
+| `feat!:` / `fix!:` / footer `BREAKING CHANGE:`      | breaking change (see below)|
+| `chore:`, `docs:`, `refactor:`, `test:`, `ci:`, `build:` | no release                 |
+
+Release notes are generated from the commit log and published only to the GitHub Releases page; no `CHANGELOG.md` is committed back to the repo.
+
+## Pre-1.0 versioning policy
+
+While the major version is `0`, breaking changes bump the **minor** version rather than jumping to `1.0.0`. So `feat!:` on `0.2.0` cuts `0.3.0`, not `1.0.0`. Once `1.0.0` is cut, breaking changes resume bumping major as usual.
+
+This keeps the pre-1.0 surface free to evolve without prematurely committing to a stable contract, while still signalling breakage clearly in release notes and version diffs.
+
+## Pinning a version
+
+`curl ... | sh` installs the latest release. To pin:
+
+```
+VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+```
+
+Or with `go install`:
+
+```
+go install github.com/jvcorredor/worktask@v0.2.0
+```

--- a/justfile
+++ b/justfile
@@ -10,6 +10,10 @@ build:
 test:
     go test ./...
 
+# Run the docs/public/install.sh test harness (POSIX shell, mocked curl)
+test-install:
+    sh tests/install/run.sh
+
 # Run go vet across all packages
 vet:
     go vet ./...
@@ -38,8 +42,8 @@ docs-build:
 lint:
     @echo "lint is not yet implemented; see https://github.com/jvcorredor/worktask/issues/10" >&2; exit 1
 
-# Run the full local CI gate (fmt-check, vet, test) in workflow order
-ci: fmt-check vet test
+# Run the full local CI gate (fmt-check, vet, test, test-install) in workflow order
+ci: fmt-check vet test test-install
 
 # Build a local snapshot release with goreleaser into ./dist (no publish)
 release-snapshot:

--- a/tests/install/run.sh
+++ b/tests/install/run.sh
@@ -1,0 +1,460 @@
+#!/bin/sh
+# POSIX test harness for docs/public/install.sh.
+#
+# Each case runs in an isolated sandbox dir. The sandbox provides:
+#   - $home_dir            a fresh $HOME (so ~/.local/bin is empty per case)
+#   - $bin_shim            a directory prepended to $PATH containing curl/uname shims
+#   - $fixtures            a directory mirroring the GitHub release URL space
+#                          (the curl shim resolves URLs to files under here)
+#
+# The shim maps:
+#   https://api.github.com/repos/jvcorredor/worktask/releases/latest
+#       -> $fixtures/latest.json
+#   https://github.com/jvcorredor/worktask/releases/download/<rest>
+#       -> $fixtures/<rest>
+#
+# Cases assemble the fixture tree they need, invoke install.sh under HOME=$home_dir
+# and the shimmed PATH, and assert on filesystem state / output / exit code.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+INSTALL_SH="$REPO_ROOT/docs/public/install.sh"
+
+failures=0
+total=0
+
+sha256_of() {
+    if command -v sha256sum >/dev/null 2>&1; then
+        sha256sum "$1" | awk '{print $1}'
+    else
+        shasum -a 256 "$1" | awk '{print $1}'
+    fi
+}
+
+make_sandbox() {
+    sandbox="$(mktemp -d "${TMPDIR:-/tmp}/wt-install-test.XXXXXX")"
+    fixtures="$sandbox/fixtures"
+    home_dir="$sandbox/home"
+    bin_shim="$sandbox/bin"
+    mkdir -p "$fixtures" "$home_dir" "$bin_shim"
+}
+
+cleanup_sandbox() {
+    [ -n "${sandbox:-}" ] && rm -rf "$sandbox"
+}
+
+# Build a fake release tarball + checksums.txt under $fixtures/<tag>/.
+# Args: tag (e.g. v0.2.0), os (linux|darwin), arch (amd64|arm64), [version_for_binary]
+# The fake binary is a shell script that prints "worktask <version>" on `version`.
+build_fixture_release() {
+    tag="$1"; os="$2"; arch="$3"
+    version="${4:-${tag#v}}"
+    rel_dir="$fixtures/$tag"
+    mkdir -p "$rel_dir"
+    build_dir="$sandbox/build.$$.$tag.$os.$arch"
+    mkdir -p "$build_dir"
+    cat >"$build_dir/worktask" <<EOF
+#!/bin/sh
+case "\$1" in
+    version|--version|-v) echo "worktask $version" ;;
+    *) echo "worktask $version" ;;
+esac
+EOF
+    chmod +x "$build_dir/worktask"
+    tarball="worktask_${version}_${os}_${arch}.tar.gz"
+    tar -czf "$rel_dir/$tarball" -C "$build_dir" worktask
+    # Append to checksums.txt (one release may have multiple platforms).
+    (
+        cd "$rel_dir"
+        printf '%s  %s\n' "$(sha256_of "$tarball")" "$tarball" >> checksums.txt
+    )
+    rm -rf "$build_dir"
+}
+
+# Write a /latest API fixture pinning to a given tag.
+fixture_latest_tag() {
+    tag="$1"
+    cat >"$fixtures/latest.json" <<EOF
+{"tag_name":"$tag","name":"$tag"}
+EOF
+}
+
+install_curl_shim() {
+    cat >"$bin_shim/curl" <<'SHIM'
+#!/bin/sh
+set -eu
+out=
+url=
+while [ $# -gt 0 ]; do
+    case "$1" in
+        -o|--output) out="$2"; shift 2 ;;
+        --) shift; break ;;
+        http*://*) url="$1"; shift ;;
+        -*) shift ;;
+        *) shift ;;
+    esac
+done
+[ -n "$url" ] || { echo "curl-shim: no URL among args" >&2; exit 22; }
+[ -n "${WT_CURL_LOG:-}" ] && printf '%s\n' "$url" >>"$WT_CURL_LOG"
+src=
+case "$url" in
+    https://api.github.com/repos/jvcorredor/worktask/releases/latest)
+        src="$WT_FIXTURES/latest.json" ;;
+    https://github.com/jvcorredor/worktask/releases/download/*)
+        rest="${url#https://github.com/jvcorredor/worktask/releases/download/}"
+        src="$WT_FIXTURES/$rest" ;;
+    *)
+        echo "curl-shim: unhandled url $url" >&2; exit 22 ;;
+esac
+[ -f "$src" ] || { echo "curl-shim: missing fixture $src (url=$url)" >&2; exit 22; }
+if [ -n "$out" ]; then
+    cp "$src" "$out"
+else
+    cat "$src"
+fi
+SHIM
+    chmod +x "$bin_shim/curl"
+}
+
+# Force platform reported by the script.  Args: kernel (Linux/Darwin), machine (x86_64/arm64/aarch64).
+install_uname_shim() {
+    cat >"$bin_shim/uname" <<SHIM
+#!/bin/sh
+kernel='$1'
+machine='$2'
+case "\$1" in
+    -s) printf '%s\n' "\$kernel" ;;
+    -m) printf '%s\n' "\$machine" ;;
+    *) /usr/bin/uname "\$@" ;;
+esac
+SHIM
+    chmod +x "$bin_shim/uname"
+}
+
+# Run install.sh in the sandbox. Extra args become a `env` prefix (KEY=VALUE ...).
+run_install() {
+    env -i \
+        HOME="$home_dir" \
+        PATH="$bin_shim:/usr/bin:/bin" \
+        WT_FIXTURES="$fixtures" \
+        WT_CURL_LOG="$sandbox/curl.log" \
+        "$@" \
+        sh "$INSTALL_SH"
+}
+
+# Run install.sh expecting failure; prints stdout/stderr to current FDs.
+run_install_expect_fail() {
+    if run_install "$@"; then
+        echo "expected install.sh to fail but it succeeded" >&2
+        return 1
+    fi
+}
+
+# === Cases ===
+
+case_tracer_bullet_default_install() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    run_install
+    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+    out="$("$home_dir/.local/bin/worktask" version)"
+    [ "$out" = "worktask 0.2.0" ] || { echo "version mismatch: $out"; return 1; }
+}
+
+case_install_dir_override() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    custom="$sandbox/custom/bin"
+    run_install INSTALL_DIR="$custom"
+    [ -x "$custom/worktask" ] || { echo "binary not in custom dir"; return 1; }
+    [ ! -e "$home_dir/.local/bin/worktask" ] || { echo "binary leaked into default dir"; return 1; }
+}
+
+case_version_pin_skips_latest_lookup() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.1.0 linux amd64
+    # Intentionally no latest.json — VERSION must skip the /latest call.
+    run_install VERSION=0.1.0
+    out="$("$home_dir/.local/bin/worktask" version)"
+    [ "$out" = "worktask 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
+}
+
+case_version_pin_accepts_v_prefix() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.1.0 linux amd64
+    run_install VERSION=v0.1.0
+    out="$("$home_dir/.local/bin/worktask" version)"
+    [ "$out" = "worktask 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
+}
+
+case_default_version_calls_latest_api() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    run_install
+    grep -qx 'https://api.github.com/repos/jvcorredor/worktask/releases/latest' \
+        "$sandbox/curl.log" \
+        || { echo "expected /releases/latest in curl log:"; cat "$sandbox/curl.log"; return 1; }
+}
+
+case_version_pin_does_not_call_latest_api() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.1.0 linux amd64
+    run_install VERSION=0.1.0
+    if grep -qx 'https://api.github.com/repos/jvcorredor/worktask/releases/latest' \
+        "$sandbox/curl.log"; then
+        echo "VERSION pin should not call /releases/latest, but it did:"
+        cat "$sandbox/curl.log"
+        return 1
+    fi
+}
+
+case_checksum_mismatch_aborts() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    # Corrupt the tarball after checksums.txt was written, so SHA won't match.
+    printf 'corrupted' >>"$fixtures/v0.2.0/worktask_0.2.0_linux_amd64.tar.gz"
+    if run_install; then
+        echo "install.sh should have failed on checksum mismatch"
+        return 1
+    fi
+    [ ! -e "$home_dir/.local/bin/worktask" ] \
+        || { echo "binary was installed despite checksum mismatch"; return 1; }
+}
+
+case_upgrade_message_when_binary_present() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.1.0 linux amd64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+
+    run_install VERSION=0.1.0
+
+    log="$sandbox/upgrade.log"
+    run_install >"$log" 2>&1
+    grep -E -q 'pgrading.*0\.1\.0.*0\.2\.0' "$log" \
+        || { echo "missing upgrade message; install output was:"; cat "$log"; return 1; }
+}
+
+case_no_upgrade_message_on_first_install() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+
+    log="$sandbox/first.log"
+    run_install >"$log" 2>&1
+    if grep -E -i -q 'upgrad' "$log"; then
+        echo "first install should not say 'upgrading'; output was:"
+        cat "$log"
+        return 1
+    fi
+}
+
+case_path_snippet_when_install_dir_off_path() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+
+    log="$sandbox/path.log"
+    # Default INSTALL_DIR ($HOME/.local/bin) is not on the sandboxed PATH.
+    run_install SHELL=/bin/bash >"$log" 2>&1
+    grep -q "$home_dir/.local/bin" "$log" \
+        || { echo "PATH snippet did not mention install dir; output:"; cat "$log"; return 1; }
+    grep -q 'export PATH' "$log" \
+        || { echo "expected bash 'export PATH' snippet; output:"; cat "$log"; return 1; }
+}
+
+case_no_path_snippet_when_install_dir_on_path() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    custom="$sandbox/onpath/bin"
+    mkdir -p "$custom"
+
+    log="$sandbox/path.log"
+    # Run install with $custom prepended to PATH so it is already discoverable.
+    env -i \
+        HOME="$home_dir" \
+        PATH="$custom:$bin_shim:/usr/bin:/bin" \
+        WT_FIXTURES="$fixtures" \
+        WT_CURL_LOG="$sandbox/curl.log" \
+        SHELL=/bin/bash \
+        INSTALL_DIR="$custom" \
+        sh "$INSTALL_SH" >"$log" 2>&1
+    if grep -q 'export PATH' "$log" || grep -q 'fish_add_path' "$log"; then
+        echo "should not print PATH snippet when install dir is already on PATH; output:"
+        cat "$log"
+        return 1
+    fi
+}
+
+case_path_snippet_fish_shell() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+
+    log="$sandbox/fish.log"
+    run_install SHELL=/usr/local/bin/fish >"$log" 2>&1
+    grep -q 'fish_add_path' "$log" \
+        || { echo "expected fish_add_path snippet; output:"; cat "$log"; return 1; }
+    if grep -q 'export PATH' "$log"; then
+        echo "fish shell should not print bash-style export; output:"
+        cat "$log"
+        return 1
+    fi
+}
+
+case_platform_linux_arm64() {
+    install_curl_shim
+    install_uname_shim Linux aarch64
+    build_fixture_release v0.2.0 linux arm64
+    fixture_latest_tag v0.2.0
+    run_install
+    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+}
+
+case_platform_darwin_amd64() {
+    install_curl_shim
+    install_uname_shim Darwin x86_64
+    build_fixture_release v0.2.0 darwin amd64
+    fixture_latest_tag v0.2.0
+    run_install
+    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+}
+
+case_platform_darwin_arm64() {
+    install_curl_shim
+    install_uname_shim Darwin arm64
+    build_fixture_release v0.2.0 darwin arm64
+    fixture_latest_tag v0.2.0
+    run_install
+    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+}
+
+case_platform_unsupported_os_aborts() {
+    install_curl_shim
+    install_uname_shim FreeBSD x86_64
+    fixture_latest_tag v0.2.0
+    log="$sandbox/err.log"
+    if run_install >"$log" 2>&1; then
+        echo "expected failure on unsupported OS; output:"
+        cat "$log"
+        return 1
+    fi
+    grep -E -i -q 'unsupported|FreeBSD' "$log" \
+        || { echo "error message did not mention unsupported OS:"; cat "$log"; return 1; }
+}
+
+case_platform_unsupported_arch_aborts() {
+    install_curl_shim
+    install_uname_shim Linux ppc64le
+    fixture_latest_tag v0.2.0
+    log="$sandbox/err.log"
+    if run_install >"$log" 2>&1; then
+        echo "expected failure on unsupported arch; output:"
+        cat "$log"
+        return 1
+    fi
+    grep -E -i -q 'unsupported|ppc64' "$log" \
+        || { echo "error message did not mention unsupported arch:"; cat "$log"; return 1; }
+}
+
+case_posix_parse_sh() {
+    sh -n "$INSTALL_SH" || { echo "sh -n parse failed"; return 1; }
+}
+
+case_posix_parse_dash() {
+    if ! command -v dash >/dev/null 2>&1; then
+        echo "skipping: dash not installed"
+        return 0
+    fi
+    dash -n "$INSTALL_SH" || { echo "dash -n parse failed"; return 1; }
+}
+
+case_install_does_not_edit_rc_files() {
+    install_curl_shim
+    install_uname_shim Linux x86_64
+    build_fixture_release v0.2.0 linux amd64
+    fixture_latest_tag v0.2.0
+    # Pre-create rc files so we can assert untouched.
+    : >"$home_dir/.bashrc"
+    : >"$home_dir/.zshrc"
+    : >"$home_dir/.profile"
+    run_install SHELL=/bin/bash >/dev/null 2>&1
+    [ ! -s "$home_dir/.bashrc" ] || { echo ".bashrc was modified"; return 1; }
+    [ ! -s "$home_dir/.zshrc" ] || { echo ".zshrc was modified"; return 1; }
+    [ ! -s "$home_dir/.profile" ] || { echo ".profile was modified"; return 1; }
+}
+
+# === Driver ===
+
+run_case() {
+    name="$1"
+    total=$((total + 1))
+    make_sandbox
+    out_file="$sandbox/out"
+    err_file="$sandbox/err"
+    rc=0
+    ( "case_$name" ) >"$out_file" 2>"$err_file" || rc=$?
+    if [ "$rc" -eq 0 ]; then
+        printf 'ok  %s\n' "$name"
+    else
+        failures=$((failures + 1))
+        printf 'FAIL %s (rc=%d)\n' "$name" "$rc"
+        echo '--- stdout ---'
+        cat "$out_file" || true
+        echo '--- stderr ---'
+        cat "$err_file" || true
+        echo '--------------'
+    fi
+    cleanup_sandbox
+}
+
+CASES='
+posix_parse_sh
+posix_parse_dash
+tracer_bullet_default_install
+install_dir_override
+version_pin_skips_latest_lookup
+version_pin_accepts_v_prefix
+default_version_calls_latest_api
+version_pin_does_not_call_latest_api
+checksum_mismatch_aborts
+upgrade_message_when_binary_present
+no_upgrade_message_on_first_install
+path_snippet_when_install_dir_off_path
+no_path_snippet_when_install_dir_on_path
+path_snippet_fish_shell
+platform_linux_arm64
+platform_darwin_amd64
+platform_darwin_arm64
+platform_unsupported_os_aborts
+platform_unsupported_arch_aborts
+install_does_not_edit_rc_files
+'
+
+for name in $CASES; do
+    run_case "$name"
+done
+
+if [ "$failures" -ne 0 ]; then
+    printf '\n%d/%d cases failed\n' "$failures" "$total" >&2
+    exit 1
+fi
+printf '\nall %d cases passed\n' "$total"


### PR DESCRIPTION
## Summary

- Adds `docs/public/install.sh` — POSIX-clean installer (`sh -n` + `dash -n` parse gates), served at `https://jvcorredor.github.io/worktask/install.sh`. Defaults to `$HOME/.local/bin`, accepts `INSTALL_DIR` and `VERSION` env-var overrides, resolves the latest tag from the GitHub releases API, downloads the platform-appropriate tarball + `checksums.txt`, verifies SHA256, extracts only the `worktask` binary, prints "Upgrading from X to Y" when re-running, and prints a shell-specific `$PATH` snippet (fish vs. bash/zsh) without editing rc files.
- 20-case POSIX test harness at `tests/install/run.sh` covering parse gates, tracer-bullet install, `INSTALL_DIR`/`VERSION` overrides, /latest API resolution (and explicit no-call when pinned), checksum mismatch abort, upgrade message + first-install silence, PATH snippet variants + on-PATH suppression + rc-files-untouched, and four supported platforms plus unsupported OS/arch error paths. Wires `just test-install` into `just ci` and adds a "Test install.sh" step to `.github/workflows/go.yml`.
- Same-PR docs per the project rule: `index.md` shows both install methods on the landing page; new `install.md` is the full reference (env vars, `$PATH`, checksum story, macOS quarantine `xattr`); new `releases.md` documents Conventional Commits + the pre-1.0 breaking-as-minor policy + a link to GH Releases. README gains a one-line install addition and a release-status badge while remaining a stub. `docs.yml` paths filter picks up `docs/public/**`.

Closes #32.

## Test plan

- [x] `just ci` passes locally (fmt-check, vet, Go tests, install-script tests).
- [x] `just docs-build` succeeds; `dist/install.sh` is published; `/install/` and `/releases/` render.
- [x] `sh -n` and `dash -n` parse `install.sh` cleanly.
- [ ] **End-to-end manual verification (blocked):** anonymous `curl ... | sh` requires the repo to be public — `api.github.com/repos/jvcorredor/worktask/releases/latest` currently 404s for anonymous callers because the repo is private. Once the repo is flipped public (or the docs-deploy is otherwise gated), run the curl-pipe install on a Linux x86_64 host and confirm `worktask version` reports the latest tag.
- [ ] On a machine where `$HOME/.local/bin` is not on `$PATH`, confirm the printed PATH snippet matches the active shell.

## Notes for the reviewer

- Workflow files in this PR (`docs.yml`, `go.yml`) — the local `gh` token lacks `workflow` scope, so an API-driven merge may 403; merge via the GitHub UI or refresh the token first.
- The script never edits rc files. `INSTALL_DIR=/usr/local/bin curl ... | sudo sh` is documented for system-wide installs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)