### PR TITLE
ci(release): add post-release smoke test for published install script

### DIFF
--- a/.github/scripts/smoke-test-version.sh
+++ b/.github/scripts/smoke-test-version.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+# Asserts that the `worktask` binary on PATH reports the version named
+# in EXPECTED_VERSION. Used by the post-release smoke-test job in
+# .github/workflows/release.yml: a mismatch fails the workflow loudly so
+# the maintainer is alerted within minutes of a broken release.
+
+set -eu
+
+die() {
+    printf '::error::%s\n' "$*" >&2
+    exit 1
+}
+
+[ -n "${EXPECTED_VERSION:-}" ] || die 'EXPECTED_VERSION is unset'
+
+command -v worktask >/dev/null 2>&1 \
+    || die 'worktask not found on PATH'
+
+actual=$(worktask version --format=json | jq -r '.version') \
+    || die 'failed to read version from worktask version --format=json'
+
+[ "$actual" = "$EXPECTED_VERSION" ] \
+    || die "worktask version mismatch: expected $EXPECTED_VERSION, got $actual"
+
+printf 'smoke test passed: worktask version reports %s\n' "$actual"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     runs-on: ubuntu-latest
     permissions:
       contents: write
+    outputs:
+      version: ${{ steps.semrel.outputs.version }}
     steps:
       - name: Checkout
         uses: actions/checkout@v6
@@ -38,9 +40,35 @@ jobs:
       # flag is silently ignored and breaking changes resume bumping
       # major.
       - name: Run semantic-release
+        id: semrel
         uses: go-semantic-release/action@v1
         with:
           allow-initial-development-versions: true
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  # Post-release guard: if a release was actually cut, fetch the live
+  # install script the same way a real user would, run it, and assert
+  # the resulting binary reports the tag we just published. Any
+  # failure - download error, checksum mismatch, missing binary,
+  # version mismatch - fails the workflow run loudly. Linux x86_64
+  # only by deliberate design (see #28); macOS and arm64 runners are
+  # out of scope for this smoke job.
+  smoke-test:
+    needs: release
+    if: needs.release.outputs.version != ''
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Install worktask via published install script
+        run: |
+          curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+          printf '%s/.local/bin\n' "$HOME" >>"$GITHUB_PATH"
+
+      - name: Assert installed binary reports the released version
+        env:
+          EXPECTED_VERSION: ${{ needs.release.outputs.version }}
+        run: sh .github/scripts/smoke-test-version.sh

--- a/justfile
+++ b/justfile
@@ -14,6 +14,10 @@ test:
 test-install:
     sh tests/install/run.sh
 
+# Run the post-release smoke-test assertion script's harness (POSIX shell, mocked worktask)
+test-smoke-version:
+    sh tests/smoke-test-version/run.sh
+
 # Run go vet across all packages
 vet:
     go vet ./...
@@ -42,8 +46,8 @@ docs-build:
 lint:
     @echo "lint is not yet implemented; see https://github.com/jvcorredor/worktask/issues/10" >&2; exit 1
 
-# Run the full local CI gate (fmt-check, vet, test, test-install) in workflow order
-ci: fmt-check vet test test-install
+# Run the full local CI gate (fmt-check, vet, test, test-install, test-smoke-version) in workflow order
+ci: fmt-check vet test test-install test-smoke-version
 
 # Build a local snapshot release with goreleaser into ./dist (no publish)
 release-snapshot:

--- a/tests/smoke-test-version/run.sh
+++ b/tests/smoke-test-version/run.sh
@@ -1,0 +1,75 @@
+#!/bin/sh
+# Black-box test for smoke-test-version.sh. Runs the script with a fake
+# `worktask` binary on PATH and verifies exit codes and stderr for each
+# behaviour the smoke-test job depends on.
+
+set -eu
+
+REPO_ROOT="$(cd "$(dirname "$0")/../.." && pwd)"
+script="$REPO_ROOT/.github/scripts/smoke-test-version.sh"
+
+fail=0
+case_name=""
+
+start_case() {
+    case_name="$1"
+}
+
+assert() {
+    if [ "$1" = "$2" ]; then
+        printf '  ok  %s\n' "$case_name"
+    else
+        printf '  FAIL %s: expected %s, got %s\n' "$case_name" "$2" "$1" >&2
+        fail=1
+    fi
+}
+
+with_fake_worktask() {
+    reported_version="$1"
+    workdir=$(mktemp -d "${TMPDIR:-/tmp}/smoke-test.XXXXXX")
+    cat >"$workdir/worktask" <<EOF
+#!/bin/sh
+cat <<JSON
+{"version":"$reported_version","commit":"abc","date":"2026-05-03","source":"ldflags"}
+JSON
+EOF
+    chmod +x "$workdir/worktask"
+    printf '%s\n' "$workdir"
+}
+
+# Case 1: matching version exits 0.
+start_case 'matching version exits 0'
+shim=$(with_fake_worktask 0.4.0)
+PATH="$shim:$PATH" EXPECTED_VERSION=0.4.0 sh "$script" >/dev/null 2>&1
+assert "$?" 0
+rm -rf "$shim"
+
+# Case 2: mismatched version exits non-zero with both versions in stderr.
+start_case 'mismatched version exits non-zero'
+shim=$(with_fake_worktask 0.3.9)
+err=$(PATH="$shim:$PATH" EXPECTED_VERSION=0.4.0 sh "$script" 2>&1 1>/dev/null) && rc=0 || rc=$?
+assert "$rc" 1
+case "$err" in
+    *0.4.0*0.3.9*|*0.3.9*0.4.0*)
+        printf '  ok  mismatch stderr names both versions\n' ;;
+    *)
+        printf '  FAIL mismatch stderr did not name both versions: %s\n' "$err" >&2
+        fail=1 ;;
+esac
+rm -rf "$shim"
+
+# Case 3: missing EXPECTED_VERSION env exits non-zero.
+start_case 'missing EXPECTED_VERSION exits non-zero'
+shim=$(with_fake_worktask 0.4.0)
+PATH="$shim:$PATH" sh "$script" >/dev/null 2>&1 && rc=0 || rc=$?
+[ "$rc" -ne 0 ] && printf '  ok  %s\n' "$case_name" || { printf '  FAIL %s: exited 0\n' "$case_name" >&2; fail=1; }
+rm -rf "$shim"
+
+# Case 4: worktask not on PATH exits non-zero.
+start_case 'missing worktask binary exits non-zero'
+empty=$(mktemp -d "${TMPDIR:-/tmp}/empty.XXXXXX")
+PATH="$empty" EXPECTED_VERSION=0.4.0 sh "$script" >/dev/null 2>&1 && rc=0 || rc=$?
+[ "$rc" -ne 0 ] && printf '  ok  %s\n' "$case_name" || { printf '  FAIL %s: exited 0\n' "$case_name" >&2; fail=1; }
+rm -rf "$empty"
+
+exit "$fail"


### PR DESCRIPTION
## Summary

- New `smoke-test` job in `release.yml` runs on `ubuntu-latest` after the release job, fetches `https://jvcorredor.github.io/worktask/install.sh`, runs it, and asserts the resulting `worktask version` reports the tag semantic-release just cut. Any failure (download, checksum, missing binary, version mismatch) fails the workflow run loudly so a broken release alerts the maintainer within minutes.
- The assertion is extracted to `.github/scripts/smoke-test-version.sh` and exercised by a POSIX shell harness at `tests/smoke-test-version/run.sh` (mirroring the existing `tests/install/` convention) covering green, mismatch, missing-env, and missing-binary paths against a fake `worktask` shim - no real GitHub release required for the unit test.
- Wired into the local CI gate via a new `just test-smoke-version` recipe and added to `just ci`.
- Linux x86_64 only by deliberate design per #28; macOS and arm64 runners are explicitly out of scope, and there is still no `shellcheck` lint job or PR-time install-script dry-run.

## Test plan

- [x] `just ci` passes locally (Go suite + install harness + new smoke-version harness, 25 cases total)
- [x] `actionlint` passes on `release.yml`
- [x] `sh -n` and `dash -n` parse-clean on both new shell files
- [ ] After merge, the next real release demonstrates the green path (smoke job passes against the freshly cut tag)
- [ ] A deliberately broken-artifact simulation demonstrates the red path (smoke job fails loudly) - acceptance criterion 6 from #33

Closes: #33

🤖 Generated with [Claude Code](https://claude.com/claude-code)