### PR TITLE
fix(build): drop go mod tidy pre-build hook from goreleaser

### DIFF
--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -2,10 +2,6 @@ version: 2
 
 project_name: worktask
 
-before:
-  hooks:
-    - go mod tidy
-
 builds:
   - id: worktask
     main: .


### PR DESCRIPTION
## Summary

- Removes the `before: hooks: [go mod tidy]` block from `.goreleaser.yaml` so goreleaser no longer rewrites `go.mod`/`go.sum` before building, which caused `+dirty` pseudo-versions in release binaries via `runtime/debug.ReadBuildInfo()`.
- `just ci` already gates go.mod hygiene on every PR, making the hook redundant.

Closes: #58