### PR TITLE
ci(release): pass --allow-no-changes to semantic-release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -36,11 +36,15 @@ jobs:
       # project on the 0.x track and treats breaking changes as
       # minor bumps until a 1.0.0 release exists; once it does, the
       # flag is silently ignored and breaking changes resume bumping
-      # major.
+      # major. --allow-no-changes makes "no release computed" a
+      # documented exit-0 path, so chore-only pushes produce a green
+      # workflow with no new tag rather than relying on the action's
+      # wrapping behavior.
       - name: Run semantic-release
         uses: go-semantic-release/action@v1
         with:
           allow-initial-development-versions: true
+          custom-arguments: --allow-no-changes
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

- Add `custom-arguments: --allow-no-changes` to the `go-semantic-release/action@v1` step in the Release workflow

## Why

When only chore/docs/refactor commits land on main, `semantic-release` computes "no new version" and exits with code 65. The workflow currently appears green only because the action wraps that exit code — the behavior is undocumented and could change on an action upgrade.

`--allow-no-changes` makes the no-change path a documented exit-0, so chore-only pushes produce a green workflow with no new tag/release via an explicit contract rather than an implementation detail of the action wrapper.

## Verification

- After merge, a chore-only push to main should produce a green Release workflow with a "no change" log line and no new tag
- A subsequent `feat:` or `fix:` push should still cut a release as before — the flag only affects the no-change path

Closes: #59