### PR TITLE
fix(ci): remove --allow-no-changes from semantic-release step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -38,16 +38,16 @@ jobs:
       # project on the 0.x track and treats breaking changes as
       # minor bumps until a 1.0.0 release exists; once it does, the
       # flag is silently ignored and breaking changes resume bumping
-      # major. --allow-no-changes makes "no release computed" a
-      # documented exit-0 path, so chore-only pushes produce a green
-      # workflow with no new tag rather than relying on the action's
-      # wrapping behavior.
+      # major. The action wrapper catches exit code 65 (no release)
+      # and returns early, so chore-only pushes produce a green
+      # workflow with no new tag. Do NOT pass --allow-no-changes;
+      # it turns the exit code into 0, which makes the action try
+      # to read the generated changelog file that was never written.
       - name: Run semantic-release
         id: semrel
         uses: go-semantic-release/action@v1
         with:
           allow-initial-development-versions: true
-          custom-arguments: --allow-no-changes
           hooks: goreleaser
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary

Reverts the `custom-arguments: --allow-no-changes` addition from #65, which broke the Release workflow on chore-only pushes.

## Root cause

`go-semantic-release/action@v1` relies on semantic-release exiting with code **65** when no version bump is computed. The action wrapper catches `6x` exit codes and returns early gracefully, producing a green workflow with no new tag.

`--allow-no-changes` changes that exit code to **0**. The action wrapper then thinks a release succeeded and tries to read `.generated-go-semantic-release-changelog.md` and `.version` — files that were never written because no release was created. This causes `ENOENT` and a failed workflow.

The failure can be seen in the run for the merge commit of #65:  
https://github.com/jvcorredor/worktask/actions/runs/25282548692

## Fix

- Remove `custom-arguments: --allow-no-changes`
- Update the inline comment to explain why the flag must not be used with this action

Chore-only pushes will once again produce a green workflow via the action's built-in exit-code-65 handling.

Refs: #65