### PR TITLE
feat(tag): add tag data model and add --tag flag

### DIFF
--- a/cmd/add.go
+++ b/cmd/add.go
@@ -4,6 +4,8 @@ import (
 	"github.com/spf13/cobra"
 )
 
+var addTags []string
+
 var addCmd = &cobra.Command{
 	Use:   "add <description>",
 	Short: "Create a new open task",
@@ -13,7 +15,7 @@ var addCmd = &cobra.Command{
 		if err != nil {
 			return err
 		}
-		t, err := s.Add(args[0])
+		t, err := s.Add(args[0], addTags...)
 		if err != nil {
 			return err
 		}
@@ -23,5 +25,6 @@ var addCmd = &cobra.Command{
 }
 
 func init() {
+	addCmd.Flags().StringArrayVar(&addTags, "tag", nil, "tag for the task (repeatable)")
 	rootCmd.AddCommand(addCmd)
 }

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -1,0 +1,167 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+func TestAddCmd_withTagsCreatesTaggedTask(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevTags := addTags
+	addTags = nil
+	t.Cleanup(func() { addTags = prevTags })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"add", "--tag", "bug", "--tag", "urgent", "fix login"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute add: %v (stderr=%s)", err, stderr.String())
+	}
+
+	if !strings.Contains(stdout.String(), "added") {
+		t.Errorf("stdout = %q, want 'added ...'", stdout.String())
+	}
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	entries, err := os.ReadDir(openDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	if len(entries) == 0 {
+		t.Fatalf("no task files found in open dir")
+	}
+
+	data, err := os.ReadFile(filepath.Join(openDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read task file: %v", err)
+	}
+	got, err := task.Decode(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("tags = %v, want [bug urgent]", got.Tags)
+	}
+}
+
+func TestAddCmd_rejectsInvalidTag(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevTags := addTags
+	addTags = nil
+	t.Cleanup(func() { addTags = prevTags })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"add", "--tag", "bug!", "fix login"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("expected error for invalid tag, got success")
+	}
+}
+
+func TestAddCmd_normalizesTagCase(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevTags := addTags
+	addTags = nil
+	t.Cleanup(func() { addTags = prevTags })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"add", "--tag", "BUG", "fix login"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute add: %v (stderr=%s)", err, stderr.String())
+	}
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	entries, err := os.ReadDir(openDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(openDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got, err := task.Decode(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "bug" {
+		t.Errorf("tags = %v, want [bug] (normalized)", got.Tags)
+	}
+}
+
+func TestAddCmd_noTagsCreatesTaskWithoutTags(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevTags := addTags
+	addTags = nil
+	t.Cleanup(func() { addTags = prevTags })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"add", "fix login"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute add: %v (stderr=%s)", err, stderr.String())
+	}
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	entries, err := os.ReadDir(openDir)
+	if err != nil {
+		t.Fatalf("readdir: %v", err)
+	}
+	data, err := os.ReadFile(filepath.Join(openDir, entries[0].Name()))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	got, err := task.Decode(data)
+	if err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Tags) != 0 {
+		t.Errorf("tags = %v, want empty", got.Tags)
+	}
+}

--- a/docs/adr/0001-tag-model.md
+++ b/docs/adr/0001-tag-model.md
@@ -1,0 +1,42 @@
+# ADR 0001: Tag model
+
+## Status
+
+Accepted
+
+## Context
+
+Tasks need lightweight categorisation that survives the file-based storage format and is accessible to both human users and programmatic consumers (agents, scripts). The design must fit the existing frontmatter codec without breaking backward compatibility.
+
+## Decision
+
+### Tag format
+
+Tags are lowercase alphanumeric strings that may contain hyphens, up to 40 characters long. The `internal/tag` package enforces this with three pure functions:
+
+- `Normalize`: lowercases and trims whitespace.
+- `Validate`: rejects characters outside `[a-z0-9-]` and lengths over 40.
+- `Deduplicate`: removes duplicates preserving first-occurrence order.
+
+### On-disk format
+
+`task.Task` gains a `Tags []string` field. `Encode` writes `tags: [a, b]\n` when Tags is non-empty (YAML flow-style list) and omits the line when Tags is empty, following the zero-value omission convention for other optional fields. `Decode` parses the `tags:` key leniently: each tag is normalised, invalid tags are silently dropped, and duplicates are removed. Unknown frontmatter keys are already tolerated, so older binaries reading newer files with `tags:` will ignore the field.
+
+### Store interface
+
+`store.Add` gains a variadic `tags ...string` parameter. Tags are normalised and validated before encoding; an invalid tag causes Add to return an error. Other store operations (Close, Reopen, Update, Append, SetResearchMeta) decode the full task and re-encode it, so tags survive by construction — no special handling needed.
+
+### CLI
+
+`add` gains a repeatable `--tag` string flag (`add --tag bug --tag urgent "fix login"`). Invalid characters produce an error at the CLI level; uppercase is silently normalised to lowercase.
+
+### JSON output
+
+`render.jsonTask` and `jsonShowTask` include `Tags []string` with `json:"tags"` (no omitempty). The field is always present — an empty array `[]` rather than `null` — so agents can `jq '.tags'` without null-checking.
+
+## Consequences
+
+- Existing task files without `tags:` remain valid; Decode returns an empty Tags slice.
+- The frontmatter format gains one optional field; the codec is backward-compatible.
+- Tags cannot be added or removed after creation without editing the file or using a future `tag` subcommand (out of scope for this slice).
+- The 40-character limit and the alphanumeric+hyphen restriction keep tags machine-friendly and filename-safe for future use (e.g. directory-based tag views).

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -7,7 +7,8 @@
 //	    "id":          string,  // 8-char lowercase hex
 //	    "created":     string,  // RFC 3339 timestamp
 //	    "description": string,  // first body line
-//	    "completed":   string   // RFC 3339; omitted when task is open
+//	    "completed":   string,  // RFC 3339; omitted when task is open
+//	    "tags":        []string // always present; empty array when no tags
 //	  },
 //	  ...
 //	]
@@ -49,10 +50,11 @@ import (
 )
 
 type jsonTask struct {
-	ID          string `json:"id"`
-	Created     string `json:"created"`
-	Description string `json:"description"`
-	Completed   string `json:"completed,omitempty"`
+	ID          string   `json:"id"`
+	Created     string   `json:"created"`
+	Description string   `json:"description"`
+	Completed   string   `json:"completed,omitempty"`
+	Tags        []string `json:"tags"`
 }
 
 type jsonShowTask struct {
@@ -286,6 +288,10 @@ func toJSONTask(t task.Task) jsonTask {
 		ID:          t.ID,
 		Created:     t.Created.Format(time.RFC3339),
 		Description: description(t),
+		Tags:        t.Tags,
+	}
+	if out.Tags == nil {
+		out.Tags = []string{}
 	}
 	if !t.Completed.IsZero() {
 		out.Completed = t.Completed.Format(time.RFC3339)

--- a/internal/render/testdata/error_no_match.json
+++ b/internal/render/testdata/error_no_match.json
@@ -5,12 +5,14 @@
     {
       "id": "11111111",
       "created": "2026-04-29T09:00:00Z",
-      "description": "first task"
+      "description": "first task",
+      "tags": []
     },
     {
       "id": "22222222",
       "created": "2026-04-29T10:00:00Z",
-      "description": "second task"
+      "description": "second task",
+      "tags": []
     }
   ]
 }

--- a/internal/render/testdata/list.json
+++ b/internal/render/testdata/list.json
@@ -2,11 +2,13 @@
   {
     "id": "11111111",
     "created": "2026-04-29T09:00:00Z",
-    "description": "first task"
+    "description": "first task",
+    "tags": []
   },
   {
     "id": "22222222",
     "created": "2026-04-29T10:00:00Z",
-    "description": "second task"
+    "description": "second task",
+    "tags": []
   }
 ]

--- a/internal/render/testdata/list_mixed.json
+++ b/internal/render/testdata/list_mixed.json
@@ -2,12 +2,14 @@
   {
     "id": "11111111",
     "created": "2026-04-29T09:00:00Z",
-    "description": "open task"
+    "description": "open task",
+    "tags": []
   },
   {
     "id": "22222222",
     "created": "2026-04-28T10:00:00Z",
     "description": "shipped feature",
-    "completed": "2026-04-30T12:00:00Z"
+    "completed": "2026-04-30T12:00:00Z",
+    "tags": []
   }
 ]

--- a/internal/render/testdata/show.json
+++ b/internal/render/testdata/show.json
@@ -2,6 +2,7 @@
   "id": "abcdef12",
   "created": "2026-04-29T11:30:00Z",
   "description": "buy milk",
+  "tags": [],
   "body": "buy milk\nremember the brand\n",
   "path": "/tasks/open/2026-04-29T11-30_abcdef12_buy-milk.md"
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -24,6 +24,7 @@ import (
 
 	"github.com/jvcorredor/worktask/internal/id"
 	"github.com/jvcorredor/worktask/internal/slug"
+	"github.com/jvcorredor/worktask/internal/tag"
 	"github.com/jvcorredor/worktask/internal/task"
 )
 
@@ -90,14 +91,27 @@ func (s *Store) AddPreserved(t task.Task, description string) error {
 }
 
 // Add creates a new open task with description as its body, assigning a
-// fresh ID and the current time as Created. The task file is written
-// under tasks_dir/open and the resulting [task.Task] is returned. The
-// open and closed subdirectories are created if missing.
-func (s *Store) Add(description string) (task.Task, error) {
+// fresh ID and the current time as Created. Any tags are normalized and
+// validated before encoding; an invalid tag causes Add to return an error.
+// The task file is written under tasks_dir/open and the resulting
+// [task.Task] is returned. The open and closed subdirectories are created
+// if missing.
+func (s *Store) Add(description string, tags ...string) (task.Task, error) {
+	normalized := make([]string, 0, len(tags))
+	for _, raw := range tags {
+		n := tag.Normalize(raw)
+		if err := tag.Validate(n); err != nil {
+			return task.Task{}, fmt.Errorf("store: invalid tag %q: %w", raw, err)
+		}
+		normalized = append(normalized, n)
+	}
+	normalized = tag.Deduplicate(normalized)
+
 	created := s.Now()
 	t := task.Task{
 		ID:      s.NewID(),
 		Created: created,
+		Tags:    normalized,
 		Body:    description + "\n",
 	}
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -808,3 +808,132 @@ func TestAdd_freshDirCreatesOpenAndClosed(t *testing.T) {
 		}
 	}
 }
+
+func TestAdd_withTagsWritesTagsInFrontmatter(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+
+	tk, err := s.Add("fix login", "bug", "urgent")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(tk.Tags) != 2 || tk.Tags[0] != "bug" || tk.Tags[1] != "urgent" {
+		t.Errorf("task.Tags = %v, want [bug urgent]", tk.Tags)
+	}
+
+	path := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_fix-login.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [bug, urgent]\n---\nfix login\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestAdd_rejectsInvalidTag(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+
+	_, err := s.Add("fix login", "bug!", "urgent")
+	if err == nil {
+		t.Fatalf("Add with invalid tag: expected error")
+	}
+}
+
+func TestAdd_normalizesTagCase(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+
+	tk, err := s.Add("fix login", "BUG", "Urgent")
+	if err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	if len(tk.Tags) != 2 || tk.Tags[0] != "bug" || tk.Tags[1] != "urgent" {
+		t.Errorf("task.Tags = %v, want [bug urgent] (normalized)", tk.Tags)
+	}
+}
+
+func TestTagsSurviveClose(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("fix login", "bug", "urgent"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
+	got, err := s.Close("abcdef12")
+	if err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("tags after close = %v, want [bug urgent]", got.Tags)
+	}
+}
+
+func TestTagsSurviveReopen(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("fix login", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
+	if _, err := s.Close("abcdef12"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	got, err := s.Reopen("abcdef12")
+	if err != nil {
+		t.Fatalf("Reopen: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "bug" {
+		t.Errorf("tags after reopen = %v, want [bug]", got.Tags)
+	}
+}
+
+func TestTagsSurviveUpdate(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("fix login", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.Update("abcdef12", "fix auth login")
+	if err != nil {
+		t.Fatalf("Update: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "bug" {
+		t.Errorf("tags after update = %v, want [bug]", got.Tags)
+	}
+}
+
+func TestTagsSurviveAppend(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("fix login", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.Append("abcdef12", "extra note\n")
+	if err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "bug" {
+		t.Errorf("tags after append = %v, want [bug]", got.Tags)
+	}
+}

--- a/internal/tag/tag.go
+++ b/internal/tag/tag.go
@@ -1,0 +1,47 @@
+// Package tag provides pure functions for normalising, validating, and
+// deduplicating task tags. Tags are lowercase alphanumeric strings that may
+// contain hyphens, up to 40 characters long.
+package tag
+
+import (
+	"fmt"
+	"strings"
+)
+
+const maxLen = 40
+
+// Normalize lowercases and trims leading and trailing whitespace.
+func Normalize(s string) string {
+	return strings.ToLower(strings.TrimSpace(s))
+}
+
+// Validate returns an error if s contains characters outside [a-z0-9-]
+// or exceeds maxLen characters.
+func Validate(s string) error {
+	if len(s) > maxLen {
+		return fmt.Errorf("tag: %q exceeds %d characters", s, maxLen)
+	}
+	for _, r := range s {
+		if !isAlnum(r) && r != '-' {
+			return fmt.Errorf("tag: %q contains invalid character %q", s, r)
+		}
+	}
+	return nil
+}
+
+func isAlnum(r rune) bool {
+	return (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+}
+
+// Deduplicate removes duplicate tags, preserving first-occurrence order.
+func Deduplicate(tags []string) []string {
+	seen := make(map[string]bool, len(tags))
+	out := make([]string, 0, len(tags))
+	for _, t := range tags {
+		if !seen[t] {
+			seen[t] = true
+			out = append(out, t)
+		}
+	}
+	return out
+}

--- a/internal/tag/tag_test.go
+++ b/internal/tag/tag_test.go
@@ -1,0 +1,62 @@
+package tag
+
+import "testing"
+
+func TestNormalizeLowercases(t *testing.T) {
+	got := Normalize("BUG")
+	want := "bug"
+	if got != want {
+		t.Errorf("Normalize(%q) = %q, want %q", "BUG", got, want)
+	}
+}
+
+func TestValidateAcceptsValidTag(t *testing.T) {
+	if err := Validate("bug"); err != nil {
+		t.Errorf("Validate(%q) = %v, want nil", "bug", err)
+	}
+}
+
+func TestValidateRejectsInvalidChars(t *testing.T) {
+	if err := Validate("bug!"); err == nil {
+		t.Errorf("Validate(%q) = nil, want error", "bug!")
+	}
+}
+
+func TestValidateRejectsTooLong(t *testing.T) {
+	long := "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	if err := Validate(long); err == nil {
+		t.Errorf("Validate(<41 chars>) = nil, want error")
+	}
+}
+
+func TestValidateAcceptsHyphen(t *testing.T) {
+	if err := Validate("high-priority"); err != nil {
+		t.Errorf("Validate(%q) = %v, want nil", "high-priority", err)
+	}
+}
+
+func TestDeduplicateRemovesDuplicates(t *testing.T) {
+	got := Deduplicate([]string{"bug", "bug", "urgent"})
+	want := []string{"bug", "urgent"}
+	if len(got) != len(want) {
+		t.Fatalf("Deduplicate len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Deduplicate[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}
+
+func TestDeduplicatePreservesOrder(t *testing.T) {
+	got := Deduplicate([]string{"urgent", "bug", "urgent"})
+	want := []string{"urgent", "bug"}
+	if len(got) != len(want) {
+		t.Fatalf("Deduplicate len = %d, want %d", len(got), len(want))
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Deduplicate[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+}

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -21,6 +21,8 @@ import (
 	"fmt"
 	"strings"
 	"time"
+
+	"github.com/jvcorredor/worktask/internal/tag"
 )
 
 // Task is the in-memory representation of one task file. The zero value
@@ -32,6 +34,7 @@ type Task struct {
 	Completed       time.Time
 	LastResearched  time.Time
 	LastResearchLog string
+	Tags            []string
 	Body            string
 }
 
@@ -41,8 +44,10 @@ const delim = "---\n"
 // frontmatter described in the package documentation followed by t.Body
 // verbatim. Zero-valued Completed and LastResearched fields are omitted
 // from the frontmatter; an empty LastResearchLog is omitted as well.
-// Encode never returns an error in the current implementation, but the
-// signature reserves room for future format-validation failures.
+// An empty Tags slice is omitted; a non-empty Tags slice is written as
+// a YAML flow-style list. Encode never returns an error in the current
+// implementation, but the signature reserves room for future
+// format-validation failures.
 func Encode(t Task) ([]byte, error) {
 	var b bytes.Buffer
 	b.WriteString(delim)
@@ -56,6 +61,9 @@ func Encode(t Task) ([]byte, error) {
 	}
 	if t.LastResearchLog != "" {
 		fmt.Fprintf(&b, "last_research_log: %s\n", t.LastResearchLog)
+	}
+	if len(t.Tags) > 0 {
+		fmt.Fprintf(&b, "tags: [%s]\n", strings.Join(t.Tags, ", "))
 	}
 	b.WriteString(delim)
 	b.WriteString(t.Body)
@@ -111,8 +119,27 @@ func Decode(data []byte) (Task, error) {
 			t.LastResearched = parsed
 		case "last_research_log":
 			t.LastResearchLog = value
+		case "tags":
+			t.Tags = parseTags(value)
 		}
 	}
 	t.Body = body
 	return t, nil
+}
+
+func parseTags(value string) []string {
+	value = strings.Trim(value, "[]")
+	if value == "" {
+		return nil
+	}
+	raw := strings.Split(value, ",")
+	var out []string
+	for _, r := range raw {
+		n := tag.Normalize(strings.TrimSpace(r))
+		if tag.Validate(n) != nil {
+			continue
+		}
+		out = append(out, n)
+	}
+	return tag.Deduplicate(out)
 }

--- a/internal/task/task_test.go
+++ b/internal/task/task_test.go
@@ -2,6 +2,7 @@ package task
 
 import (
 	"os"
+	"strings"
 	"testing"
 	"time"
 )
@@ -125,5 +126,81 @@ func TestFormatStability_openTask(t *testing.T) {
 	}
 	if string(encoded) != string(fixture) {
 		t.Errorf("Encode(want) bytes do not match fixture.\n--- got ---\n%s\n--- want ---\n%s", encoded, fixture)
+	}
+}
+
+func TestEncodeOmitsTagsWhenEmpty(t *testing.T) {
+	tk := Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Body:    "buy milk\n",
+	}
+	got, err := Encode(tk)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if strings.Contains(string(got), "tags:") {
+		t.Errorf("Encode with no tags should omit tags line, got:\n%s", got)
+	}
+}
+
+func TestEncodeWritesTagsWhenNonEmpty(t *testing.T) {
+	tk := Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Tags:    []string{"bug", "urgent"},
+		Body:    "buy milk\n",
+	}
+	got, err := Encode(tk)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [bug, urgent]\n---\nbuy milk\n"
+	if string(got) != want {
+		t.Errorf("Encode with tags:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestDecodeParsesTags(t *testing.T) {
+	input := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [bug, urgent]\n---\nbuy milk\n"
+	got, err := Decode([]byte(input))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("Tags = %v, want [bug urgent]", got.Tags)
+	}
+}
+
+func TestDecodeNormalizesTagCase(t *testing.T) {
+	input := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [BUG, Urgent]\n---\nbuy milk\n"
+	got, err := Decode([]byte(input))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("Tags = %v, want [bug urgent] (normalized)", got.Tags)
+	}
+}
+
+func TestDecodeDropsInvalidTag(t *testing.T) {
+	input := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [bug, no!good, urgent]\n---\nbuy milk\n"
+	got, err := Decode([]byte(input))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("Tags = %v, want [bug urgent] (invalid dropped)", got.Tags)
+	}
+}
+
+func TestDecodeDeduplicatesTags(t *testing.T) {
+	input := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [bug, bug, urgent]\n---\nbuy milk\n"
+	got, err := Decode([]byte(input))
+	if err != nil {
+		t.Fatalf("Decode: %v", err)
+	}
+	if len(got.Tags) != 2 || got.Tags[0] != "bug" || got.Tags[1] != "urgent" {
+		t.Errorf("Tags = %v, want [bug urgent] (deduplicated)", got.Tags)
 	}
 }


### PR DESCRIPTION
## Summary

- Introduce `internal/tag` package with `Normalize`, `Validate`, `Deduplicate` pure functions
- Add `Tags []string` field to `task.Task`; `Encode` writes `tags: [a, b]` (omitted when empty), `Decode` parses leniently (normalizes, drops invalid, deduplicates)
- `store.Add` gains variadic `tags ...string` parameter; normalizes and validates before encoding
- `add --tag bug --tag urgent "fix login"` creates a task with tags in frontmatter; invalid tag chars rejected with error; uppercase silently normalized
- JSON output always includes `"tags": []` (never omitted) so agents can `jq '.tags'` without null-checking
- All existing JSON golden files updated; tags survive close/reopen/update/append by construction
- ADR 0001 documents tag design decisions

Closes: #75