### PR TITLE
feat(tag): add tag add and tag rm subcommands

### DIFF
--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,0 +1,54 @@
+package cmd
+
+import (
+	"github.com/spf13/cobra"
+)
+
+var tagCmd = &cobra.Command{
+	Use:   "tag",
+	Short: "Mutate tags on existing tasks",
+}
+
+var tagAddCmd = &cobra.Command{
+	Use:   "add <fragment> <tag>",
+	Short: "Add a tag to an existing task",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fragment, rawTag := args[0], args[1]
+		s, err := newStore()
+		if err != nil {
+			return err
+		}
+		t, err := s.AddTag(fragment, rawTag)
+		if err != nil {
+			return handleResolveError(cmd, s, fragment, err)
+		}
+		cmd.Printf("tagged %s with %s\n", t.ID, rawTag)
+		return nil
+	},
+}
+
+var tagRmCmd = &cobra.Command{
+	Use:   "rm <fragment> <tag>",
+	Short: "Remove a tag from an existing task",
+	Args:  cobra.ExactArgs(2),
+	RunE: func(cmd *cobra.Command, args []string) error {
+		fragment, rawTag := args[0], args[1]
+		s, err := newStore()
+		if err != nil {
+			return err
+		}
+		t, err := s.RemoveTag(fragment, rawTag)
+		if err != nil {
+			return handleResolveError(cmd, s, fragment, err)
+		}
+		cmd.Printf("removed %s from %s\n", rawTag, t.ID)
+		return nil
+	},
+}
+
+func init() {
+	tagCmd.AddCommand(tagAddCmd)
+	tagCmd.AddCommand(tagRmCmd)
+	rootCmd.AddCommand(tagCmd)
+}

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -1,0 +1,121 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+// TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage is the
+// end-to-end test for `worktask tag rm <fragment> <tag>`.
+func TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tk := task.Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Tags:    []string{"urgent", "shopping"},
+		Body:    "buy milk\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("task.Encode: %v", err)
+	}
+	openPath := filepath.Join(openDir, "2026-04-29T11-30_abcdef12_buy-milk.md")
+	if err := os.WriteFile(openPath, raw, 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "rm", "abcdef12", "urgent"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag rm: %v (stderr=%s)", err, stderr.String())
+	}
+
+	if got, want := strings.TrimRight(stdout.String(), "\n"), "removed urgent from abcdef12"; got != want {
+		t.Errorf("tag rm stdout = %q; want %q", got, want)
+	}
+
+	data, err := os.ReadFile(openPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [shopping]\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+// TestTagAddCmd_addsTagToOpenTaskAndPrintsTaggedID is the end-to-end
+// test for `worktask tag add <fragment> <tag>`.
+func TestTagAddCmd_addsTagToOpenTaskAndPrintsTaggedID(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tk := task.Task{
+		ID:      "abcdef12",
+		Created: time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		Body:    "buy milk\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("task.Encode: %v", err)
+	}
+	openPath := filepath.Join(openDir, "2026-04-29T11-30_abcdef12_buy-milk.md")
+	if err := os.WriteFile(openPath, raw, 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "add", "abcdef12", "urgent"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag add: %v (stderr=%s)", err, stderr.String())
+	}
+
+	if got, want := strings.TrimRight(stdout.String(), "\n"), "tagged abcdef12 with urgent"; got != want {
+		t.Errorf("tag add stdout = %q; want %q", got, want)
+	}
+
+	data, err := os.ReadFile(openPath)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [urgent]\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -24,6 +24,8 @@ worktask append <fragment> <text>
 worktask close <fragment>
 worktask reopen <fragment>
 worktask edit <fragment>
+worktask tag add <fragment> <tag>
+worktask tag rm <fragment> <tag>
 worktask research [<fragment>]
 worktask version
 ```
@@ -113,6 +115,24 @@ The inverse of `close`: moves the file back to `open/` and clears the `completed
 
 ```
 $ worktask reopen milk
+```
+
+## `tag add`
+
+Adds a tag to an existing task. The tag is normalized (lower-cased, trimmed) and validated against `[a-z0-9-]` up to 40 characters. Re-running with the same tag is a no-op.
+
+```
+$ worktask tag add milk urgent
+tagged abcdef12 with urgent
+```
+
+## `tag rm`
+
+Removes a tag from an existing task. Re-running with an absent tag is a no-op. When the last tag is removed, the `tags:` frontmatter line is omitted entirely.
+
+```
+$ worktask tag rm milk urgent
+removed urgent from abcdef12
 ```
 
 ## `edit`

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -1,7 +1,7 @@
 ---
 title: Reference slash command
 description: Manage tasks via the worktask CLI
-argument-hint: <add|list|show|close|reopen|update|append|edit|research|research-log> [args...]
+argument-hint: <add|list|show|close|reopen|update|append|tag|edit|research|research-log> [args...]
 ---
 
 Manage tasks via the `worktask` CLI. Task state lives in per-task markdown files under the configured XDG data directory; this command never reads, parses, or rewrites `WORKING.md` or any task file directly. The CLI owns ID generation, slug generation, match resolution, and formatting.
@@ -19,6 +19,8 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 | `reopen <frag>` | `worktask --format=json reopen "<frag>"` |
 | `update <frag> <new description>` | `worktask --format=json update "<frag>" "<new description>"` |
 | `append <frag> <text>` | `worktask --format=json append "<frag>" "<text>"` |
+| `tag add <frag> <tag>` | `worktask tag add "<frag>" "<tag>"` |
+| `tag rm <frag> <tag>` | `worktask tag rm "<frag>" "<tag>"` |
 | `edit <frag>` | see below — do NOT shell out to `worktask edit` |
 | `research [<frag>]` | see "research" below — invokes a background bash, returns an ack, reports back when done |
 | `research-log <frag>` | `worktask research-log "<frag>"` |
@@ -38,7 +40,7 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 ## Success output
 
 - `list` and `show` return JSON. Render as a readable summary, or pass through.
-- `add`, `update`, `append`, `close`, `reopen` print a single line (e.g. `added 1e3900e4`). Pass through.
+- `add`, `update`, `append`, `close`, `reopen`, `tag add`, `tag rm` print a single line (e.g. `added 1e3900e4`). Pass through.
 
 ## `edit <frag>`
 

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -362,6 +362,72 @@ func (s *Store) Path(fragment string) (string, error) {
 	return l.path, nil
 }
 
+// AddTag resolves fragment, normalizes and validates tag, appends it
+// to the task's tags if not already present, re-encodes the task, and
+// rewrites the file in place. Returns [*ErrNoMatch] or [*ErrAmbiguous]
+// when fragment does not resolve. Prints an error and returns a non-nil
+// error if the tag is invalid after normalization.
+func (s *Store) AddTag(fragment, rawTag string) (task.Task, error) {
+	l, err := s.resolve(fragment, []string{"open", "closed"})
+	if err != nil {
+		return task.Task{}, err
+	}
+	t := l.task
+	n := tag.Normalize(rawTag)
+	if err := tag.Validate(n); err != nil {
+		return task.Task{}, fmt.Errorf("store: invalid tag %q: %w", rawTag, err)
+	}
+	for _, existing := range t.Tags {
+		if existing == n {
+			return t, nil
+		}
+	}
+	t.Tags = append(t.Tags, n)
+	data, err := task.Encode(t)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("store: encode: %w", err)
+	}
+	if err := os.WriteFile(l.path, data, 0o644); err != nil {
+		return task.Task{}, fmt.Errorf("store: write %s: %w", l.path, err)
+	}
+	return t, nil
+}
+
+// RemoveTag resolves fragment, normalizes tag, removes it from the
+// task's tags if present, re-encodes the task, and rewrites the file in
+// place. When the last tag is removed, the tags frontmatter line is
+// omitted. Returns [*ErrNoMatch] or [*ErrAmbiguous] when fragment does
+// not resolve. Re-running with an absent tag is a no-op.
+func (s *Store) RemoveTag(fragment, rawTag string) (task.Task, error) {
+	l, err := s.resolve(fragment, []string{"open", "closed"})
+	if err != nil {
+		return task.Task{}, err
+	}
+	t := l.task
+	n := tag.Normalize(rawTag)
+	if err := tag.Validate(n); err != nil {
+		return task.Task{}, fmt.Errorf("store: invalid tag %q: %w", rawTag, err)
+	}
+	var filtered []string
+	for _, existing := range t.Tags {
+		if existing != n {
+			filtered = append(filtered, existing)
+		}
+	}
+	if len(filtered) == len(t.Tags) {
+		return t, nil
+	}
+	t.Tags = filtered
+	data, err := task.Encode(t)
+	if err != nil {
+		return task.Task{}, fmt.Errorf("store: encode: %w", err)
+	}
+	if err := os.WriteFile(l.path, data, 0o644); err != nil {
+		return task.Task{}, fmt.Errorf("store: write %s: %w", l.path, err)
+	}
+	return t, nil
+}
+
 // Append concatenates text to the body of the task identified by
 // fragment, inserting a separating newline when the existing body does
 // not already end with one, and rewrites the file in place. The task's

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -937,3 +937,204 @@ func TestTagsSurviveAppend(t *testing.T) {
 		t.Errorf("tags after append = %v, want [bug]", got.Tags)
 	}
 }
+
+func TestAddTag_addsTagToTaskWithNoTags(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.AddTag("abcdef12", "urgent")
+	if err != nil {
+		t.Fatalf("AddTag: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "urgent" {
+		t.Errorf("tags after AddTag = %v, want [urgent]", got.Tags)
+	}
+
+	path := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_buy-milk.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [urgent]\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestAddTag_idempotent(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk", "urgent"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.AddTag("abcdef12", "urgent")
+	if err != nil {
+		t.Fatalf("AddTag: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "urgent" {
+		t.Errorf("tags after idempotent AddTag = %v, want [urgent]", got.Tags)
+	}
+
+	path := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_buy-milk.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [urgent]\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestAddTag_normalizesUppercaseTag(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.AddTag("abcdef12", "URGENT")
+	if err != nil {
+		t.Fatalf("AddTag: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "urgent" {
+		t.Errorf("tags after AddTag = %v, want [urgent] (normalized)", got.Tags)
+	}
+}
+
+func TestAddTag_rejectsInvalidTag(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, err := s.AddTag("abcdef12", "bad tag!")
+	if err == nil {
+		t.Fatalf("AddTag with invalid tag: expected error")
+	}
+}
+
+func TestAddTag_zeroMatchReturnsTypedError(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, err := s.AddTag("nonexistent-zzz", "urgent")
+	if err == nil {
+		t.Fatalf("AddTag: expected error")
+	}
+	var nm *ErrNoMatch
+	if !errors.As(err, &nm) {
+		t.Fatalf("error type = %T (%v); want *ErrNoMatch", err, err)
+	}
+}
+
+func TestRemoveTag_removesTagAndRewritesFile(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk", "urgent", "shopping"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.RemoveTag("abcdef12", "urgent")
+	if err != nil {
+		t.Fatalf("RemoveTag: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "shopping" {
+		t.Errorf("tags after RemoveTag = %v, want [shopping]", got.Tags)
+	}
+
+	path := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_buy-milk.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\ntags: [shopping]\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestRemoveTag_idempotent(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk", "shopping"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.RemoveTag("abcdef12", "urgent")
+	if err != nil {
+		t.Fatalf("RemoveTag: %v", err)
+	}
+	if len(got.Tags) != 1 || got.Tags[0] != "shopping" {
+		t.Errorf("tags after idempotent RemoveTag = %v, want [shopping]", got.Tags)
+	}
+}
+
+func TestRemoveTag_removingLastTagOmitsTagsLine(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk", "urgent"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.RemoveTag("abcdef12", "urgent")
+	if err != nil {
+		t.Fatalf("RemoveTag: %v", err)
+	}
+	if len(got.Tags) != 0 {
+		t.Errorf("tags after RemoveTag = %v, want []", got.Tags)
+	}
+
+	path := filepath.Join(dir, "open", "2026-04-29T11-30_abcdef12_buy-milk.md")
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	want := "---\nid: abcdef12\ncreated: 2026-04-29T11:30:00Z\n---\nbuy milk\n"
+	if string(data) != want {
+		t.Errorf("file contents:\n--- got ---\n%s\n--- want ---\n%s", data, want)
+	}
+}
+
+func TestRemoveTag_zeroMatchReturnsTypedError(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC) }
+	s.NewID = func() string { return "abcdef12" }
+	if _, err := s.Add("buy milk", "urgent"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	_, err := s.RemoveTag("nonexistent-zzz", "urgent")
+	if err == nil {
+		t.Fatalf("RemoveTag: expected error")
+	}
+	var nm *ErrNoMatch
+	if !errors.As(err, &nm) {
+		t.Fatalf("error type = %T (%v); want *ErrNoMatch", err, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds `worktask tag add <fragment> <tag>` and `worktask tag rm <fragment> <tag>` so agents and humans can mutate tags on existing tasks.

## What changed

- **store** — new `AddTag` and `RemoveTag` methods:
  - Resolve fragment via existing `resolve()` (open + closed)
  - Normalise + validate tag via `internal/tag`
  - Rewrite file in place with updated frontmatter
  - Idempotent: re-adding an existing tag or re-removing a missing tag is a no-op
  - Removing the last tag omits the `tags:` line entirely

- **cmd** — new `tag` command group with `add` and `rm` subcommands:
  - `tag add` prints `tagged <id> with <tag>`
  - `tag rm` prints `removed <tag> from <id>`
  - Both delegate ambiguous/no-match errors to `handleResolveError`

- **tests** — store-level and end-to-end tests covering idempotency, validation, normalisation, zero-match typed errors, and file contents

- **docs** — updated CLI reference and vendored slash-command spec

## Acceptance criteria

- [x] `store.AddTag` idempotently adds a tag
- [x] `store.RemoveTag` idempotently removes a tag
- [x] Removing the last tag omits the `tags:` frontmatter line
- [x] `worktask tag add abc1 bug` prints `tagged <id> with bug`
- [x] `worktask tag rm abc1 bug` prints `removed bug from <id>`
- [x] Invalid tag characters rejected with error; uppercase silently normalized
- [x] Ambiguous/no-match fragment errors handled via existing `handleResolveError`
- [x] `just ci` passes

Closes: #77