### PR TITLE
feat(tag): add tag ls subcommand for tag discovery

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jvcorredor/worktask/internal/render"
 	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/worktask/internal/tag"
 	"github.com/jvcorredor/worktask/internal/tty"
 )
 
@@ -16,6 +17,7 @@ var (
 	listAll    bool
 	listClosed bool
 	listLimit  int
+	listTag    string
 )
 
 var listCmd = &cobra.Command{
@@ -41,7 +43,15 @@ var listCmd = &cobra.Command{
 			limit = listLimit
 		}
 
-		tasks, err := s.List(filter, limit)
+		var normalizedTag string
+		if listTag != "" {
+			normalizedTag = tag.Normalize(listTag)
+			if err := tag.Validate(normalizedTag); err != nil {
+				return fmt.Errorf("invalid --tag %q: %w", listTag, err)
+			}
+		}
+
+		tasks, err := s.List(filter, limit, normalizedTag)
 		if err != nil {
 			return err
 		}
@@ -66,5 +76,6 @@ func init() {
 	listCmd.Flags().BoolVar(&listAll, "all", false, "include closed tasks alongside open")
 	listCmd.Flags().BoolVar(&listClosed, "closed", false, "show closed tasks only")
 	listCmd.Flags().IntVar(&listLimit, "limit", 0, "cap on closed entries (default 20)")
+	listCmd.Flags().StringVar(&listTag, "tag", "", "filter to tasks carrying this tag (exact match)")
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -10,6 +10,91 @@ import (
 	"github.com/jvcorredor/worktask/internal/task"
 )
 
+// TestListCmd_tagFlagFiltersToTaggedTasks is the end-to-end test for
+// `worktask list --tag bug`: only tasks with that tag appear; uppercase
+// is normalized.
+func TestListCmd_tagFlagFiltersToTaggedTasks(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tasks := []task.Task{
+		{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"bug"}, Body: "first\n"},
+		{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Tags: []string{"infra"}, Body: "second\n"},
+	}
+	for _, tk := range tasks {
+		raw, err := task.Encode(tk)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		listTag = ""
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"list", "--tag", "BUG"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute list --tag: %v (stderr=%s)", err, stderr.String())
+	}
+
+	want := "11111111  2026-04-29 09:00  [bug]  first\n"
+	if stdout.String() != want {
+		t.Errorf("list --tag output mismatch.\n--- got ---\n%q\n--- want ---\n%q", stdout.String(), want)
+	}
+}
+
+// TestListCmd_tagFlagInvalidValueErrors verifies that an invalid tag
+// (per tag.Validate) is rejected with a clear error before any task is
+// loaded.
+func TestListCmd_tagFlagInvalidValueErrors(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		listTag = ""
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"list", "--tag", "bad tag"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("list --tag 'bad tag': expected error, got nil (stdout=%s)", stdout.String())
+	}
+}
+
 // TestListCmd_humanPipeModeIsPlain is the end-to-end pipe-mode test:
 // when stdout is a non-TTY writer (here, *bytes.Buffer), `worktask list`
 // must emit the plain `id  YYYY-MM-DD HH:MM  [tags]  description\n` rows

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -139,7 +139,7 @@ type itemMeta struct {
 }
 
 func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store) error {
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -70,7 +70,7 @@ func handleResolveError(cmd *cobra.Command, s *store.Store, fragment string, err
 		}
 		return errExit
 	case errors.As(err, &nm):
-		openTasks, lerr := s.List(store.FilterOpen, 0)
+		openTasks, lerr := s.List(store.FilterOpen, 0, "")
 		if lerr != nil {
 			return lerr
 		}

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -1,12 +1,60 @@
 package cmd
 
 import (
+	"fmt"
+
 	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/worktask/internal/render"
+	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/worktask/internal/tty"
 )
 
 var tagCmd = &cobra.Command{
 	Use:   "tag",
-	Short: "Mutate tags on existing tasks",
+	Short: "Mutate and discover tags on tasks",
+}
+
+var (
+	tagLsAll    bool
+	tagLsClosed bool
+)
+
+var tagLsCmd = &cobra.Command{
+	Use:   "ls",
+	Short: "List distinct tags in use, with counts",
+	Args:  cobra.NoArgs,
+	RunE: func(cmd *cobra.Command, args []string) error {
+		s, err := newStore()
+		if err != nil {
+			return err
+		}
+		filter := store.FilterOpen
+		switch {
+		case tagLsClosed:
+			filter = store.FilterClosed
+		case tagLsAll:
+			filter = store.FilterAll
+		}
+		tagCounts, err := s.ListTags(filter)
+		if err != nil {
+			return err
+		}
+		switch format {
+		case formatJSON:
+			data, err := render.JSONTagList(tagCounts)
+			if err != nil {
+				return err
+			}
+			_, err = cmd.OutOrStdout().Write(data)
+			return err
+		case formatHuman:
+			out := cmd.OutOrStdout()
+			return render.HumanTagList(out, tagCounts, tty.IsTerminal(out))
+		default:
+			return fmt.Errorf("unknown format: %s", format)
+		}
+	},
 }
 
 var tagAddCmd = &cobra.Command{
@@ -48,7 +96,10 @@ var tagRmCmd = &cobra.Command{
 }
 
 func init() {
+	tagLsCmd.Flags().BoolVar(&tagLsAll, "all", false, "include closed tasks alongside open")
+	tagLsCmd.Flags().BoolVar(&tagLsClosed, "closed", false, "scan closed tasks only")
 	tagCmd.AddCommand(tagAddCmd)
 	tagCmd.AddCommand(tagRmCmd)
+	tagCmd.AddCommand(tagLsCmd)
 	rootCmd.AddCommand(tagCmd)
 }

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -11,6 +11,265 @@ import (
 	"github.com/jvcorredor/worktask/internal/task"
 )
 
+// TestTagLsCmd_jsonModeReturnsTagsEnvelope is the end-to-end test for
+// `worktask --format=json tag ls`: stdout is the {"tags": [...]} envelope
+// with entries sorted alphabetically.
+func TestTagLsCmd_jsonModeReturnsTagsEnvelope(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tasks := []task.Task{
+		{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"infra", "urgent"}, Body: "first\n"},
+		{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Tags: []string{"infra", "bug"}, Body: "second\n"},
+	}
+	for _, tk := range tasks {
+		raw, err := task.Encode(tk)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prevFormat := format
+	format = formatJSON
+	t.Cleanup(func() { format = prevFormat })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "ls"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag ls: %v (stderr=%s)", err, stderr.String())
+	}
+
+	want := "{\n  \"tags\": [\n    {\n      \"name\": \"bug\",\n      \"count\": 1\n    },\n    {\n      \"name\": \"infra\",\n      \"count\": 2\n    },\n    {\n      \"name\": \"urgent\",\n      \"count\": 1\n    }\n  ]\n}\n"
+	if stdout.String() != want {
+		t.Errorf("tag ls JSON output mismatch.\n--- got ---\n%s\n--- want ---\n%s", stdout.String(), want)
+	}
+}
+
+// TestTagLsCmd_humanModeEmitsSpaceSeparatedLine is the end-to-end test
+// for `worktask tag ls`: in human mode, output is a single line of
+// "name (count)" entries with no header, no ANSI escapes — the contract
+// pipe-mode callers rely on for grep/awk.
+func TestTagLsCmd_humanModeEmitsSpaceSeparatedLine(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tasks := []task.Task{
+		{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"infra", "urgent"}, Body: "first\n"},
+		{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Tags: []string{"infra", "bug"}, Body: "second\n"},
+	}
+	for _, tk := range tasks {
+		raw, err := task.Encode(tk)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() { format = prevFormat })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "ls"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag ls: %v (stderr=%s)", err, stderr.String())
+	}
+
+	want := "bug (1)  infra (2)  urgent (1)\n"
+	if stdout.String() != want {
+		t.Errorf("tag ls human output mismatch.\n--- got ---\n%q\n--- want ---\n%q", stdout.String(), want)
+	}
+	if bytes.ContainsRune(stdout.Bytes(), '\x1b') {
+		t.Errorf("tag ls pipe-mode output must not contain ANSI escapes, got %q", stdout.String())
+	}
+}
+
+// TestTagLsCmd_emptyCorpusEmitsBlankLineHuman pins the empty contract:
+// human-mode tag ls on a corpus with no tags emits a single blank line.
+func TestTagLsCmd_emptyCorpusEmitsBlankLineHuman(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() { format = prevFormat })
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "ls"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag ls: %v (stderr=%s)", err, stderr.String())
+	}
+
+	if stdout.String() != "\n" {
+		t.Errorf("empty tag ls = %q; want %q", stdout.String(), "\n")
+	}
+}
+
+// TestTagLsCmd_closedFlagFiltersToClosedTagsOnly verifies that --closed
+// scopes the scan to closed tasks only — open-only tags do not appear.
+func TestTagLsCmd_closedFlagFiltersToClosedTagsOnly(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	closedDir := filepath.Join(tmp, "worktask", "closed")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir open: %v", err)
+	}
+	if err := os.MkdirAll(closedDir, 0o755); err != nil {
+		t.Fatalf("mkdir closed: %v", err)
+	}
+
+	openTask := task.Task{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"open-only"}, Body: "open\n"}
+	openRaw, err := task.Encode(openTask)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(openDir, "open.md"), openRaw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	closedTask := task.Task{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Completed: time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC), Tags: []string{"closed-only"}, Body: "closed\n"}
+	closedRaw, err := task.Encode(closedTask)
+	if err != nil {
+		t.Fatalf("Encode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(closedDir, "closed.md"), closedRaw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		tagLsClosed = false
+		tagLsAll = false
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "ls", "--closed"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag ls --closed: %v (stderr=%s)", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	if !strings.Contains(got, "closed-only") {
+		t.Errorf("--closed output should contain closed-only tag; got %q", got)
+	}
+	if strings.Contains(got, "open-only") {
+		t.Errorf("--closed output must not contain open-only tag; got %q", got)
+	}
+}
+
+// TestTagLsCmd_allFlagIncludesOpenAndClosed verifies that --all scans
+// both open and closed tasks.
+func TestTagLsCmd_allFlagIncludesOpenAndClosed(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	closedDir := filepath.Join(tmp, "worktask", "closed")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir open: %v", err)
+	}
+	if err := os.MkdirAll(closedDir, 0o755); err != nil {
+		t.Fatalf("mkdir closed: %v", err)
+	}
+
+	openTask := task.Task{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"open-only"}, Body: "open\n"}
+	openRaw, _ := task.Encode(openTask)
+	if err := os.WriteFile(filepath.Join(openDir, "open.md"), openRaw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	closedTask := task.Task{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Completed: time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC), Tags: []string{"closed-only"}, Body: "closed\n"}
+	closedRaw, _ := task.Encode(closedTask)
+	if err := os.WriteFile(filepath.Join(closedDir, "closed.md"), closedRaw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		tagLsClosed = false
+		tagLsAll = false
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"tag", "ls", "--all"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute tag ls --all: %v (stderr=%s)", err, stderr.String())
+	}
+
+	got := strings.TrimRight(stdout.String(), "\n")
+	if !strings.Contains(got, "open-only") {
+		t.Errorf("--all output should contain open-only tag; got %q", got)
+	}
+	if !strings.Contains(got, "closed-only") {
+		t.Errorf("--all output should contain closed-only tag; got %q", got)
+	}
+}
+
 // TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage is the
 // end-to-end test for `worktask tag rm <fragment> <tag>`.
 func TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage(t *testing.T) {

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -26,6 +26,7 @@ worktask reopen <fragment>
 worktask edit <fragment>
 worktask tag add <fragment> <tag>
 worktask tag rm <fragment> <tag>
+worktask tag ls [--all] [--closed]
 worktask research [<fragment>]
 worktask version
 ```
@@ -133,6 +134,37 @@ Removes a tag from an existing task. Re-running with an absent tag is a no-op. W
 ```
 $ worktask tag rm milk urgent
 removed urgent from abcdef12
+```
+
+## `tag ls`
+
+Reports each distinct tag in the corpus along with the count of tasks carrying it, sorted alphabetically by tag name. Tags with zero occurrences never appear — the listing is derived from task files; tags are not pre-registered.
+
+Flags:
+
+- `--all` includes closed tasks alongside open.
+- `--closed` scans closed tasks only.
+
+Default is open tasks only — same semantics as [`list`](#list).
+
+In `--format=human`, output is a single space-padded line of `name (count)` entries, no header, no ANSI escapes. An empty corpus emits a blank line.
+
+```
+$ worktask tag ls
+bug (3)  infra (5)  urgent (2)
+```
+
+In `--format=json`, output is `{"tags": [{"name": ..., "count": ...}, ...]}`. The `tags` key is always present (empty array when none) so consumers can `jq '.tags'` without null-checking.
+
+```
+$ worktask --format=json tag ls
+{
+  "tags": [
+    {"name": "bug",    "count": 3},
+    {"name": "infra",  "count": 5},
+    {"name": "urgent", "count": 2}
+  ]
+}
 ```
 
 ## `edit`

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -17,7 +17,7 @@ JSON output is intended for agentic consumers; the schema is documented as stabl
 
 ```
 worktask add <description>
-worktask list [--all] [--closed] [--limit N]
+worktask list [--all] [--closed] [--limit N] [--tag TAG]
 worktask show <fragment>
 worktask update <fragment> <new description>
 worktask append <fragment> <text>
@@ -55,11 +55,14 @@ Flags:
 - `--all` includes closed tasks (truncated to the most recent 20).
 - `--closed` shows closed tasks only.
 - `--limit N` overrides the truncation.
+- `--tag TAG` filters to tasks carrying the tag (single value, exact match after lowercase normalization). Composes as logical AND with `--all`/`--closed`. A non-matching tag returns an empty list with no error; an invalid tag value (whitespace, uppercase that doesn't normalize cleanly, characters outside `[a-z0-9-]`) is rejected.
 
 ```
 $ worktask list
 $ worktask list --all
 $ worktask list --closed --limit 50
+$ worktask list --tag bug
+$ worktask list --tag infra --all
 ```
 
 In `--format=human`, the rendering is TTY-aware:

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -13,7 +13,7 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 | Subcommand | Shell |
 |---|---|
 | `add <description>` | `worktask --format=json add "<description>"` |
-| `list` (also `--all`, `--closed`, `--limit N`) | `worktask --format=json list [flags]` |
+| `list` (also `--all`, `--closed`, `--limit N`, `--tag TAG`) | `worktask --format=json list [flags]` |
 | `show <frag>` | `worktask --format=json show "<frag>"` |
 | `close <frag>` | `worktask --format=json close "<frag>"` |
 | `reopen <frag>` | `worktask --format=json reopen "<frag>"` |

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -21,6 +21,7 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 | `append <frag> <text>` | `worktask --format=json append "<frag>" "<text>"` |
 | `tag add <frag> <tag>` | `worktask tag add "<frag>" "<tag>"` |
 | `tag rm <frag> <tag>` | `worktask tag rm "<frag>" "<tag>"` |
+| `tag ls` (also `--all`, `--closed`) | `worktask --format=json tag ls [flags]` |
 | `edit <frag>` | see below — do NOT shell out to `worktask edit` |
 | `research [<frag>]` | see "research" below — invokes a background bash, returns an ack, reports back when done |
 | `research-log <frag>` | `worktask research-log "<frag>"` |
@@ -39,7 +40,7 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 
 ## Success output
 
-- `list` and `show` return JSON. Render as a readable summary, or pass through.
+- `list`, `show`, and `tag ls` return JSON. Render as a readable summary, or pass through. (`tag ls` returns `{"tags": [{"name": ..., "count": ...}, ...]}`; the `tags` key is always present.)
 - `add`, `update`, `append`, `close`, `reopen`, `tag add`, `tag rm` print a single line (e.g. `added 1e3900e4`). Pass through.
 
 ## `edit <frag>`

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -274,6 +274,26 @@ func JSONList(tasks []task.Task) ([]byte, error) {
 	return marshalIndent(out)
 }
 
+type jsonTagCount struct {
+	Name  string `json:"name"`
+	Count int    `json:"count"`
+}
+
+type jsonTagList struct {
+	Tags []jsonTagCount `json:"tags"`
+}
+
+// JSONTagList renders the tag-list envelope: {"tags": [{"name": ...,
+// "count": ...}, ...]}. The tags key is always present; an empty input
+// renders as an empty array, never null.
+func JSONTagList(tagCounts []store.TagCount) ([]byte, error) {
+	out := make([]jsonTagCount, 0, len(tagCounts))
+	for _, tc := range tagCounts {
+		out = append(out, jsonTagCount{Name: tc.Name, Count: tc.Count})
+	}
+	return marshalIndent(jsonTagList{Tags: out})
+}
+
 func marshalIndent(v any) ([]byte, error) {
 	var buf bytes.Buffer
 	enc := json.NewEncoder(&buf)
@@ -333,6 +353,21 @@ func HumanCandidates(w io.Writer, candidates []store.Candidate, styled bool) err
 		}
 	}
 	return nil
+}
+
+// HumanTagList writes a single line of "name (count)" entries separated
+// by two spaces to w, terminated with a newline. An empty input emits a
+// blank line. The styled flag is accepted for parity with sibling
+// renderers; output is byte-identical in both modes (no table layout).
+// Returns the first write error encountered.
+func HumanTagList(w io.Writer, tagCounts []store.TagCount, styled bool) error {
+	_ = styled
+	parts := make([]string, 0, len(tagCounts))
+	for _, tc := range tagCounts {
+		parts = append(parts, fmt.Sprintf("%s (%d)", tc.Name, tc.Count))
+	}
+	_, err := fmt.Fprintln(w, strings.Join(parts, "  "))
+	return err
 }
 
 // HumanList writes one line per task to w. When styled is false the

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -574,6 +574,82 @@ func TestHumanShow_styledIncludesFaintPathLineBetweenMetadataAndBody(t *testing.
 	}
 }
 
+func TestHumanTagList_unstyledSpaceSeparatesEntries(t *testing.T) {
+	tagCounts := []store.TagCount{
+		{Name: "bug", Count: 3},
+		{Name: "infra", Count: 5},
+		{Name: "urgent", Count: 2},
+	}
+	var buf bytes.Buffer
+	if err := HumanTagList(&buf, tagCounts, false); err != nil {
+		t.Fatalf("HumanTagList: %v", err)
+	}
+	want, err := os.ReadFile("testdata/tag_ls_human_unstyled.txt")
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if !bytes.Equal(buf.Bytes(), want) {
+		t.Errorf("HumanTagList unstyled does not match snapshot.\n--- got ---\n%q\n--- want ---\n%q", buf.String(), string(want))
+	}
+}
+
+func TestHumanTagList_emptyEmitsBlankLine(t *testing.T) {
+	var buf bytes.Buffer
+	if err := HumanTagList(&buf, nil, false); err != nil {
+		t.Fatalf("HumanTagList: %v", err)
+	}
+	if buf.String() != "\n" {
+		t.Errorf("empty HumanTagList = %q; want %q", buf.String(), "\n")
+	}
+}
+
+func TestHumanTagList_styledMatchesUnstyled(t *testing.T) {
+	tagCounts := []store.TagCount{
+		{Name: "bug", Count: 3},
+		{Name: "infra", Count: 5},
+	}
+	var styledBuf, unstyledBuf bytes.Buffer
+	if err := HumanTagList(&styledBuf, tagCounts, true); err != nil {
+		t.Fatalf("HumanTagList styled: %v", err)
+	}
+	if err := HumanTagList(&unstyledBuf, tagCounts, false); err != nil {
+		t.Fatalf("HumanTagList unstyled: %v", err)
+	}
+	if !bytes.Equal(styledBuf.Bytes(), unstyledBuf.Bytes()) {
+		t.Errorf("styled and unstyled outputs must be byte-identical for tag list.\n--- styled ---\n%q\n--- unstyled ---\n%q", styledBuf.String(), unstyledBuf.String())
+	}
+}
+
+func TestJSONTagList_emptyEmitsTagsEmptyArray(t *testing.T) {
+	got, err := JSONTagList(nil)
+	if err != nil {
+		t.Fatalf("JSONTagList: %v", err)
+	}
+	want := "{\n  \"tags\": []\n}\n"
+	if string(got) != want {
+		t.Errorf("empty JSONTagList:\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestJSONTagList_matchesSnapshot(t *testing.T) {
+	tagCounts := []store.TagCount{
+		{Name: "bug", Count: 3},
+		{Name: "infra", Count: 5},
+		{Name: "urgent", Count: 2},
+	}
+	got, err := JSONTagList(tagCounts)
+	if err != nil {
+		t.Fatalf("JSONTagList: %v", err)
+	}
+	want, err := os.ReadFile("testdata/tag_ls.json")
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("JSON output does not match snapshot.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
 func TestJSONShow_matchesSnapshot(t *testing.T) {
 	tk := task.Task{
 		ID:      "abcdef12",

--- a/internal/render/testdata/tag_ls.json
+++ b/internal/render/testdata/tag_ls.json
@@ -1,0 +1,16 @@
+{
+  "tags": [
+    {
+      "name": "bug",
+      "count": 3
+    },
+    {
+      "name": "infra",
+      "count": 5
+    },
+    {
+      "name": "urgent",
+      "count": 2
+    }
+  ]
+}

--- a/internal/render/testdata/tag_ls_human_unstyled.txt
+++ b/internal/render/testdata/tag_ls_human_unstyled.txt
@@ -1,0 +1,1 @@
+bug (3)  infra (5)  urgent (2)

--- a/internal/render/zzgen_test.go
+++ b/internal/render/zzgen_test.go
@@ -1,9 +1,12 @@
 package render
 
 import (
+	"bytes"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/jvcorredor/worktask/internal/store"
 )
 
 // TestZGenerateGoldenFiles is a one-shot helper enabled with WORKTASK_GOLDEN=1
@@ -46,6 +49,23 @@ func TestZGenerateGoldenFiles(t *testing.T) {
 			Error: "context deadline exceeded",
 		})
 	})
+	emit("tag_ls.json", func() ([]byte, error) {
+		return JSONTagList([]store.TagCount{
+			{Name: "bug", Count: 3},
+			{Name: "infra", Count: 5},
+			{Name: "urgent", Count: 2},
+		})
+	})
+	emit("tag_ls_human_unstyled.txt", func() ([]byte, error) {
+		var buf bytes.Buffer
+		err := HumanTagList(&buf, []store.TagCount{
+			{Name: "bug", Count: 3},
+			{Name: "infra", Count: 5},
+			{Name: "urgent", Count: 2},
+		}, false)
+		return buf.Bytes(), err
+	})
+
 	emit("research_summary.json", func() ([]byte, error) {
 		return JSONResearchSummary(ResearchSummary{
 			BatchID:  "2026-05-01T14:00:00Z",

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -135,6 +135,37 @@ func (s *Store) Add(description string, tags ...string) (task.Task, error) {
 	return t, nil
 }
 
+// TagCount is one entry in the result of [Store.ListTags]: a tag name
+// and the number of tasks (within the requested filter) that carry it.
+type TagCount struct {
+	Name  string
+	Count int
+}
+
+// ListTags scans the tasks selected by filter and returns each distinct
+// tag in use along with the count of tasks carrying it, sorted by Name.
+// Tags with zero occurrences never appear (the listing is derived from
+// task files; tags are not pre-registered). A missing subdirectory is
+// treated as empty rather than as an error.
+func (s *Store) ListTags(filter Filter) ([]TagCount, error) {
+	tasks, err := s.List(filter, 0)
+	if err != nil {
+		return nil, err
+	}
+	counts := make(map[string]int)
+	for _, t := range tasks {
+		for _, name := range t.Tags {
+			counts[name]++
+		}
+	}
+	out := make([]TagCount, 0, len(counts))
+	for name, n := range counts {
+		out = append(out, TagCount{Name: name, Count: n})
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Name < out[j].Name })
+	return out, nil
+}
+
 // List returns the tasks selected by filter. Open tasks are returned in
 // directory order; closed tasks are sorted by Completed descending and
 // truncated to closedLimit when closedLimit is positive. When filter is

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,7 +148,7 @@ type TagCount struct {
 // task files; tags are not pre-registered). A missing subdirectory is
 // treated as empty rather than as an error.
 func (s *Store) ListTags(filter Filter) ([]TagCount, error) {
-	tasks, err := s.List(filter, 0)
+	tasks, err := s.List(filter, 0, "")
 	if err != nil {
 		return nil, err
 	}
@@ -169,22 +169,26 @@ func (s *Store) ListTags(filter Filter) ([]TagCount, error) {
 // List returns the tasks selected by filter. Open tasks are returned in
 // directory order; closed tasks are sorted by Completed descending and
 // truncated to closedLimit when closedLimit is positive. When filter is
-// [FilterAll], the result is open tasks followed by closed tasks.
+// [FilterAll], the result is open tasks followed by closed tasks. When
+// tagFilter is non-empty, only tasks whose Tags slice contains the
+// (already-normalized) tag are returned; the tag filter composes as
+// AND with filter and is applied before the closedLimit cap.
 // A missing subdirectory is treated as empty rather than as an error.
-func (s *Store) List(filter Filter, closedLimit int) ([]task.Task, error) {
+func (s *Store) List(filter Filter, closedLimit int, tagFilter string) ([]task.Task, error) {
 	var open, closed []task.Task
 	if filter == FilterOpen || filter == FilterAll {
 		ts, err := s.loadDir("open")
 		if err != nil {
 			return nil, err
 		}
-		open = ts
+		open = filterByTag(ts, tagFilter)
 	}
 	if filter == FilterClosed || filter == FilterAll {
 		ts, err := s.loadDir("closed")
 		if err != nil {
 			return nil, err
 		}
+		ts = filterByTag(ts, tagFilter)
 		sort.Slice(ts, func(i, j int) bool { return ts[j].Completed.Before(ts[i].Completed) })
 		if closedLimit > 0 && len(ts) > closedLimit {
 			ts = ts[:closedLimit]
@@ -192,6 +196,22 @@ func (s *Store) List(filter Filter, closedLimit int) ([]task.Task, error) {
 		closed = ts
 	}
 	return append(open, closed...), nil
+}
+
+func filterByTag(tasks []task.Task, tagFilter string) []task.Task {
+	if tagFilter == "" {
+		return tasks
+	}
+	out := make([]task.Task, 0, len(tasks))
+	for _, t := range tasks {
+		for _, tg := range t.Tags {
+			if tg == tagFilter {
+				out = append(out, t)
+				break
+			}
+		}
+	}
+	return out
 }
 
 func (s *Store) loadDir(sub string) ([]task.Task, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -73,7 +73,7 @@ func TestList_returnsOpenTasksInChronologicalOrder(t *testing.T) {
 		t.Fatalf("Add second: %v", err)
 	}
 
-	tasks, err := s.List(FilterOpen, 0)
+	tasks, err := s.List(FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestList_filterClosedSortsByCompletedDescending(t *testing.T) {
 		t.Fatalf("Close second: %v", err)
 	}
 
-	tasks, err := s.List(FilterClosed, 20)
+	tasks, err := s.List(FilterClosed, 20, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestList_filterClosedHonorsLimit(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterClosed, 3)
+	tasks, err := s.List(FilterClosed, 3, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -512,7 +512,7 @@ func TestList_filterAllReturnsOpenUncappedAndClosedCapped(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterAll, 2)
+	tasks, err := s.List(FilterAll, 2, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -544,12 +544,127 @@ func TestList_filterOpenIgnoresLimit(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterOpen, 2)
+	tasks, err := s.List(FilterOpen, 2, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 	if len(tasks) != 5 {
 		t.Errorf("len(tasks) = %d; want 5 (open never truncated by limit)", len(tasks))
+	}
+}
+
+func TestList_tagFilterNarrowsToTaggedTasks(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("first", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("second", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "33333333" }
+	if _, err := s.Add("third", "bug", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "bug")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d; want 2 (only tasks tagged 'bug')", len(got))
+	}
+	for _, tk := range got {
+		hasBug := false
+		for _, tg := range tk.Tags {
+			if tg == "bug" {
+				hasBug = true
+			}
+		}
+		if !hasBug {
+			t.Errorf("returned task %s lacks 'bug' tag (tags=%v)", tk.ID, tk.Tags)
+		}
+	}
+}
+
+func TestList_tagFilterReturnsEmptyForNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("only", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "nonexistent")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d; want 0 (non-matching tag should return empty list, no error)", len(got))
+	}
+}
+
+func TestList_tagFilterComposesAcrossOpenAndClosed(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("open-bug", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("closed-bug", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
+	if _, err := s.Close("22222222"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "33333333" }
+	if _, err := s.Add("infra-only", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterAll, 0, "bug")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d; want 2 (one open + one closed bug)", len(got))
+	}
+}
+
+func TestList_emptyTagFilterIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("untagged"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("tagged", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d; want 2 (empty tag must not filter)", len(got))
 	}
 }
 

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -1138,3 +1138,130 @@ func TestRemoveTag_zeroMatchReturnsTypedError(t *testing.T) {
 		t.Fatalf("error type = %T (%v); want *ErrNoMatch", err, err)
 	}
 }
+
+func TestListTags_emptyCorpusReturnsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	got, err := s.ListTags(FilterOpen)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("ListTags on empty corpus = %v; want empty", got)
+	}
+}
+
+func TestListTags_filterScopesWhichTasksAreScanned(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("open task", "open-only", "shared"); err != nil {
+		t.Fatalf("Add open: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("closed task", "closed-only", "shared"); err != nil {
+		t.Fatalf("Add closed: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
+	if _, err := s.Close("22222222"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+
+	openTags, err := s.ListTags(FilterOpen)
+	if err != nil {
+		t.Fatalf("ListTags(FilterOpen): %v", err)
+	}
+	if got := tagNames(openTags); !equalStrings(got, []string{"open-only", "shared"}) {
+		t.Errorf("FilterOpen tag names = %v; want [open-only shared]", got)
+	}
+
+	closedTags, err := s.ListTags(FilterClosed)
+	if err != nil {
+		t.Fatalf("ListTags(FilterClosed): %v", err)
+	}
+	if got := tagNames(closedTags); !equalStrings(got, []string{"closed-only", "shared"}) {
+		t.Errorf("FilterClosed tag names = %v; want [closed-only shared]", got)
+	}
+
+	allTags, err := s.ListTags(FilterAll)
+	if err != nil {
+		t.Fatalf("ListTags(FilterAll): %v", err)
+	}
+	gotAll := map[string]int{}
+	for _, tc := range allTags {
+		gotAll[tc.Name] = tc.Count
+	}
+	wantAll := map[string]int{"open-only": 1, "closed-only": 1, "shared": 2}
+	for k, v := range wantAll {
+		if gotAll[k] != v {
+			t.Errorf("FilterAll count[%q] = %d; want %d (full=%v)", k, gotAll[k], v, allTags)
+		}
+	}
+	if len(allTags) != len(wantAll) {
+		t.Errorf("FilterAll len = %d; want %d", len(allTags), len(wantAll))
+	}
+}
+
+func tagNames(tcs []TagCount) []string {
+	out := make([]string, 0, len(tcs))
+	for _, tc := range tcs {
+		out = append(out, tc.Name)
+	}
+	return out
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestListTags_returnsDistinctTagsWithCountsSortedByName(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("first", "infra", "urgent"); err != nil {
+		t.Fatalf("Add first: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("second", "infra", "bug"); err != nil {
+		t.Fatalf("Add second: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "33333333" }
+	if _, err := s.Add("third", "infra"); err != nil {
+		t.Fatalf("Add third: %v", err)
+	}
+
+	got, err := s.ListTags(FilterOpen)
+	if err != nil {
+		t.Fatalf("ListTags: %v", err)
+	}
+
+	want := []TagCount{
+		{Name: "bug", Count: 1},
+		{Name: "infra", Count: 3},
+		{Name: "urgent", Count: 1},
+	}
+	if len(got) != len(want) {
+		t.Fatalf("len(got) = %d; want %d (got=%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("got[%d] = %v; want %v", i, got[i], w)
+		}
+	}
+}

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -31,7 +31,7 @@ func TestRun_TracerBullet(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestRun_TracerBullet(t *testing.T) {
 		t.Errorf("open task body = %q, want %q", got, want)
 	}
 
-	closedTasks, err := s.List(store.FilterClosed, 0)
+	closedTasks, err := s.List(store.FilterClosed, 0, "")
 	if err != nil {
 		t.Fatalf("List closed: %v", err)
 	}
@@ -109,14 +109,14 @@ func TestRun_RefusesWhenAlreadyMigrated(t *testing.T) {
 		t.Fatal("second Run: expected error, got nil")
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}
 	if len(openTasks) != 1 {
 		t.Errorf("open tasks after rerun = %d, want 1 (no duplicates)", len(openTasks))
 	}
-	closedTasks, err := s.List(store.FilterClosed, 0)
+	closedTasks, err := s.List(store.FilterClosed, 0, "")
 	if err != nil {
 		t.Fatalf("List closed: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestRun_AbsorbsIndentedContinuation(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Adds `worktask tag ls` so agents and humans can discover what tags exist (sorted alphabetically by name, with counts).
- New `store.ListTags(filter)`, `render.JSONTagList`, `render.HumanTagList`. `--all` / `--closed` flags compose with the same semantics as `list`.
- New goldens `tag_ls.json` and `tag_ls_human_unstyled.txt`, regenerable via `WORKTASK_GOLDEN=1`.

JSON envelope keeps `tags` always present (empty array when none) per the parent PRD's null-free schema rule.

Docs site (`cli.md`) and the vendored slash-command reference are updated in the same PR per the same-PR docs rule in CLAUDE.md.

Closes #78.

## Test plan
- [x] `just ci` passes (fmt-check, vet, test, test-install, test-smoke-version)
- [x] `golangci-lint run` passes
- [x] Manual smoke test against a tempdir corpus: `tag ls`, `--format=json tag ls`, `--all`, `--closed` all produce expected output
- [ ] Reviewer verifies the JSON shape matches the brief and the `tags` key is never null

🤖 Generated with [Claude Code](https://claude.com/claude-code)