### PR TITLE
feat(list): add --tag flag to filter by single tag

### DIFF
--- a/cmd/list.go
+++ b/cmd/list.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/jvcorredor/worktask/internal/render"
 	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/worktask/internal/tag"
 	"github.com/jvcorredor/worktask/internal/tty"
 )
 
@@ -16,6 +17,7 @@ var (
 	listAll    bool
 	listClosed bool
 	listLimit  int
+	listTag    string
 )
 
 var listCmd = &cobra.Command{
@@ -41,7 +43,15 @@ var listCmd = &cobra.Command{
 			limit = listLimit
 		}
 
-		tasks, err := s.List(filter, limit)
+		var normalizedTag string
+		if listTag != "" {
+			normalizedTag = tag.Normalize(listTag)
+			if err := tag.Validate(normalizedTag); err != nil {
+				return fmt.Errorf("invalid --tag %q: %w", listTag, err)
+			}
+		}
+
+		tasks, err := s.List(filter, limit, normalizedTag)
 		if err != nil {
 			return err
 		}
@@ -66,5 +76,6 @@ func init() {
 	listCmd.Flags().BoolVar(&listAll, "all", false, "include closed tasks alongside open")
 	listCmd.Flags().BoolVar(&listClosed, "closed", false, "show closed tasks only")
 	listCmd.Flags().IntVar(&listLimit, "limit", 0, "cap on closed entries (default 20)")
+	listCmd.Flags().StringVar(&listTag, "tag", "", "filter to tasks carrying this tag (exact match)")
 	rootCmd.AddCommand(listCmd)
 }

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -10,6 +10,91 @@ import (
 	"github.com/jvcorredor/worktask/internal/task"
 )
 
+// TestListCmd_tagFlagFiltersToTaggedTasks is the end-to-end test for
+// `worktask list --tag bug`: only tasks with that tag appear; uppercase
+// is normalized.
+func TestListCmd_tagFlagFiltersToTaggedTasks(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	tasks := []task.Task{
+		{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"bug"}, Body: "first\n"},
+		{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Tags: []string{"infra"}, Body: "second\n"},
+	}
+	for _, tk := range tasks {
+		raw, err := task.Encode(tk)
+		if err != nil {
+			t.Fatalf("Encode: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		listTag = ""
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"list", "--tag", "BUG"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute list --tag: %v (stderr=%s)", err, stderr.String())
+	}
+
+	want := "11111111  2026-04-29 09:00  [bug]  first\n"
+	if stdout.String() != want {
+		t.Errorf("list --tag output mismatch.\n--- got ---\n%q\n--- want ---\n%q", stdout.String(), want)
+	}
+}
+
+// TestListCmd_tagFlagInvalidValueErrors verifies that an invalid tag
+// (per tag.Validate) is rejected with a clear error before any task is
+// loaded.
+func TestListCmd_tagFlagInvalidValueErrors(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	prevFormat := format
+	format = formatHuman
+	t.Cleanup(func() {
+		format = prevFormat
+		listTag = ""
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"list", "--tag", "bad tag"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err := rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("list --tag 'bad tag': expected error, got nil (stdout=%s)", stdout.String())
+	}
+}
+
 // TestListCmd_humanPipeModeIsPlain is the end-to-end pipe-mode test:
 // when stdout is a non-TTY writer (here, *bytes.Buffer), `worktask list`
 // must emit the plain `id  YYYY-MM-DD HH:MM  [tags]  description\n` rows

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -139,7 +139,7 @@ type itemMeta struct {
 }
 
 func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store) error {
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		return err
 	}

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -70,7 +70,7 @@ func handleResolveError(cmd *cobra.Command, s *store.Store, fragment string, err
 		}
 		return errExit
 	case errors.As(err, &nm):
-		openTasks, lerr := s.List(store.FilterOpen, 0)
+		openTasks, lerr := s.List(store.FilterOpen, 0, "")
 		if lerr != nil {
 			return lerr
 		}

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -17,7 +17,7 @@ JSON output is intended for agentic consumers; the schema is documented as stabl
 
 ```
 worktask add <description>
-worktask list [--all] [--closed] [--limit N]
+worktask list [--all] [--closed] [--limit N] [--tag TAG]
 worktask show <fragment>
 worktask update <fragment> <new description>
 worktask append <fragment> <text>
@@ -55,11 +55,14 @@ Flags:
 - `--all` includes closed tasks (truncated to the most recent 20).
 - `--closed` shows closed tasks only.
 - `--limit N` overrides the truncation.
+- `--tag TAG` filters to tasks carrying the tag (single value, exact match after lowercase normalization). Composes as logical AND with `--all`/`--closed`. A non-matching tag returns an empty list with no error; an invalid tag value (whitespace, uppercase that doesn't normalize cleanly, characters outside `[a-z0-9-]`) is rejected.
 
 ```
 $ worktask list
 $ worktask list --all
 $ worktask list --closed --limit 50
+$ worktask list --tag bug
+$ worktask list --tag infra --all
 ```
 
 In `--format=human`, the rendering is TTY-aware:

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -13,7 +13,7 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 | Subcommand | Shell |
 |---|---|
 | `add <description>` | `worktask --format=json add "<description>"` |
-| `list` (also `--all`, `--closed`, `--limit N`) | `worktask --format=json list [flags]` |
+| `list` (also `--all`, `--closed`, `--limit N`, `--tag TAG`) | `worktask --format=json list [flags]` |
 | `show <frag>` | `worktask --format=json show "<frag>"` |
 | `close <frag>` | `worktask --format=json close "<frag>"` |
 | `reopen <frag>` | `worktask --format=json reopen "<frag>"` |

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -148,7 +148,7 @@ type TagCount struct {
 // task files; tags are not pre-registered). A missing subdirectory is
 // treated as empty rather than as an error.
 func (s *Store) ListTags(filter Filter) ([]TagCount, error) {
-	tasks, err := s.List(filter, 0)
+	tasks, err := s.List(filter, 0, "")
 	if err != nil {
 		return nil, err
 	}
@@ -169,22 +169,26 @@ func (s *Store) ListTags(filter Filter) ([]TagCount, error) {
 // List returns the tasks selected by filter. Open tasks are returned in
 // directory order; closed tasks are sorted by Completed descending and
 // truncated to closedLimit when closedLimit is positive. When filter is
-// [FilterAll], the result is open tasks followed by closed tasks.
+// [FilterAll], the result is open tasks followed by closed tasks. When
+// tagFilter is non-empty, only tasks whose Tags slice contains the
+// (already-normalized) tag are returned; the tag filter composes as
+// AND with filter and is applied before the closedLimit cap.
 // A missing subdirectory is treated as empty rather than as an error.
-func (s *Store) List(filter Filter, closedLimit int) ([]task.Task, error) {
+func (s *Store) List(filter Filter, closedLimit int, tagFilter string) ([]task.Task, error) {
 	var open, closed []task.Task
 	if filter == FilterOpen || filter == FilterAll {
 		ts, err := s.loadDir("open")
 		if err != nil {
 			return nil, err
 		}
-		open = ts
+		open = filterByTag(ts, tagFilter)
 	}
 	if filter == FilterClosed || filter == FilterAll {
 		ts, err := s.loadDir("closed")
 		if err != nil {
 			return nil, err
 		}
+		ts = filterByTag(ts, tagFilter)
 		sort.Slice(ts, func(i, j int) bool { return ts[j].Completed.Before(ts[i].Completed) })
 		if closedLimit > 0 && len(ts) > closedLimit {
 			ts = ts[:closedLimit]
@@ -192,6 +196,22 @@ func (s *Store) List(filter Filter, closedLimit int) ([]task.Task, error) {
 		closed = ts
 	}
 	return append(open, closed...), nil
+}
+
+func filterByTag(tasks []task.Task, tagFilter string) []task.Task {
+	if tagFilter == "" {
+		return tasks
+	}
+	out := make([]task.Task, 0, len(tasks))
+	for _, t := range tasks {
+		for _, tg := range t.Tags {
+			if tg == tagFilter {
+				out = append(out, t)
+				break
+			}
+		}
+	}
+	return out
 }
 
 func (s *Store) loadDir(sub string) ([]task.Task, error) {

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -73,7 +73,7 @@ func TestList_returnsOpenTasksInChronologicalOrder(t *testing.T) {
 		t.Fatalf("Add second: %v", err)
 	}
 
-	tasks, err := s.List(FilterOpen, 0)
+	tasks, err := s.List(FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -444,7 +444,7 @@ func TestList_filterClosedSortsByCompletedDescending(t *testing.T) {
 		t.Fatalf("Close second: %v", err)
 	}
 
-	tasks, err := s.List(FilterClosed, 20)
+	tasks, err := s.List(FilterClosed, 20, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -476,7 +476,7 @@ func TestList_filterClosedHonorsLimit(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterClosed, 3)
+	tasks, err := s.List(FilterClosed, 3, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -512,7 +512,7 @@ func TestList_filterAllReturnsOpenUncappedAndClosedCapped(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterAll, 2)
+	tasks, err := s.List(FilterAll, 2, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
@@ -544,12 +544,127 @@ func TestList_filterOpenIgnoresLimit(t *testing.T) {
 		}
 	}
 
-	tasks, err := s.List(FilterOpen, 2)
+	tasks, err := s.List(FilterOpen, 2, "")
 	if err != nil {
 		t.Fatalf("List: %v", err)
 	}
 	if len(tasks) != 5 {
 		t.Errorf("len(tasks) = %d; want 5 (open never truncated by limit)", len(tasks))
+	}
+}
+
+func TestList_tagFilterNarrowsToTaggedTasks(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("first", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("second", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "33333333" }
+	if _, err := s.Add("third", "bug", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "bug")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("len(got) = %d; want 2 (only tasks tagged 'bug')", len(got))
+	}
+	for _, tk := range got {
+		hasBug := false
+		for _, tg := range tk.Tags {
+			if tg == "bug" {
+				hasBug = true
+			}
+		}
+		if !hasBug {
+			t.Errorf("returned task %s lacks 'bug' tag (tags=%v)", tk.ID, tk.Tags)
+		}
+	}
+}
+
+func TestList_tagFilterReturnsEmptyForNoMatch(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("only", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "nonexistent")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 0 {
+		t.Errorf("len(got) = %d; want 0 (non-matching tag should return empty list, no error)", len(got))
+	}
+}
+
+func TestList_tagFilterComposesAcrossOpenAndClosed(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("open-bug", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("closed-bug", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 30, 9, 0, 0, 0, time.UTC) }
+	if _, err := s.Close("22222222"); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "33333333" }
+	if _, err := s.Add("infra-only", "infra"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterAll, 0, "bug")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d; want 2 (one open + one closed bug)", len(got))
+	}
+}
+
+func TestList_emptyTagFilterIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("untagged"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("tagged", "bug"); err != nil {
+		t.Fatalf("Add: %v", err)
+	}
+
+	got, err := s.List(FilterOpen, 0, "")
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(got) != 2 {
+		t.Errorf("len(got) = %d; want 2 (empty tag must not filter)", len(got))
 	}
 }
 

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -31,7 +31,7 @@ func TestRun_TracerBullet(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}
@@ -52,7 +52,7 @@ func TestRun_TracerBullet(t *testing.T) {
 		t.Errorf("open task body = %q, want %q", got, want)
 	}
 
-	closedTasks, err := s.List(store.FilterClosed, 0)
+	closedTasks, err := s.List(store.FilterClosed, 0, "")
 	if err != nil {
 		t.Fatalf("List closed: %v", err)
 	}
@@ -109,14 +109,14 @@ func TestRun_RefusesWhenAlreadyMigrated(t *testing.T) {
 		t.Fatal("second Run: expected error, got nil")
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}
 	if len(openTasks) != 1 {
 		t.Errorf("open tasks after rerun = %d, want 1 (no duplicates)", len(openTasks))
 	}
-	closedTasks, err := s.List(store.FilterClosed, 0)
+	closedTasks, err := s.List(store.FilterClosed, 0, "")
 	if err != nil {
 		t.Fatalf("List closed: %v", err)
 	}
@@ -155,7 +155,7 @@ func TestRun_AbsorbsIndentedContinuation(t *testing.T) {
 		t.Fatalf("Run: %v", err)
 	}
 
-	openTasks, err := s.List(store.FilterOpen, 0)
+	openTasks, err := s.List(store.FilterOpen, 0, "")
 	if err != nil {
 		t.Fatalf("List open: %v", err)
 	}


### PR DESCRIPTION
## Summary
- Adds `worktask list --tag <tag>` for single-tag filtering. Composes as AND with `--all`/`--closed`/`--limit`.
- Tag value is normalized via `tag.Normalize` and validated via `tag.Validate` before any tasks are read; invalid tags are rejected with a clear error.
- A non-matching tag returns an empty list with no error (per parent PRD #74).
- `store.List` gains a `tagFilter string` parameter; empty string preserves prior behaviour. All callers updated (`cmd/list`, `cmd/research`, `cmd/show`, `store.ListTags`, migrate tests).

Stacked on #91 (#78). Closes #79.

## Test plan
- [x] `just ci` passes
- [x] `golangci-lint run` passes
- [x] New tests cover: empty tag = no-op, narrowing, FilterAll composition, no-match returns empty, --tag normalizes uppercase, invalid tag is rejected
- [ ] Reviewer confirms the signature change is appropriate (a `ListOpts` struct was the alternative; positional was chosen for minimal churn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)