### PR TITLE
feat(research): add --tag flag to scope batch sweeps

### DIFF
--- a/cmd/research.go
+++ b/cmd/research.go
@@ -28,6 +28,7 @@ var (
 	researchStale       time.Duration
 	researchTimeout     time.Duration
 	researchModel       string
+	researchTag         string
 )
 
 const (
@@ -40,6 +41,14 @@ var researchCmd = &cobra.Command{
 	Short: "Research one task or sweep every open task via headless claude agents",
 	Args:  cobra.MaximumNArgs(1),
 	RunE: func(cmd *cobra.Command, args []string) error {
+		if len(args) == 1 && cmd.Flags().Changed("tag") {
+			return fmt.Errorf("--tag is not valid in single-task mode (drop the fragment to sweep all tagged tasks)")
+		}
+		normalizedTag, err := validateResearchTag(researchTag)
+		if err != nil {
+			return err
+		}
+
 		cfg, err := config.Load()
 		if err != nil {
 			return err
@@ -49,7 +58,7 @@ var researchCmd = &cobra.Command{
 		if len(args) == 1 {
 			return runSingleResearch(cmd, cfg, s, args[0])
 		}
-		return runBatchResearch(cmd, cfg, s)
+		return runBatchResearch(cmd, cfg, s, normalizedTag)
 	},
 }
 
@@ -59,6 +68,7 @@ func init() {
 	researchCmd.Flags().DurationVar(&researchStale, "stale", 0, "re-research tasks whose last_researched is older than this duration")
 	researchCmd.Flags().DurationVar(&researchTimeout, "timeout", defaultResearchTimeout, "per-task hard timeout")
 	researchCmd.Flags().StringVar(&researchModel, "model", "", "claude model id for the research agent; overrides config.research_model")
+	researchCmd.Flags().StringVar(&researchTag, "tag", "", "in batch mode, restrict the sweep to open tasks carrying this tag (exact match)")
 	rootCmd.AddCommand(researchCmd)
 }
 
@@ -138,8 +148,8 @@ type itemMeta struct {
 	runStart   time.Time
 }
 
-func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store) error {
-	openTasks, err := s.List(store.FilterOpen, 0, "")
+func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, tagFilter string) error {
+	openTasks, err := s.List(store.FilterOpen, 0, tagFilter)
 	if err != nil {
 		return err
 	}

--- a/cmd/research_tag.go
+++ b/cmd/research_tag.go
@@ -1,0 +1,21 @@
+package cmd
+
+import (
+	"fmt"
+
+	"github.com/jvcorredor/worktask/internal/tag"
+)
+
+// validateResearchTag normalizes raw and verifies it is a syntactically
+// valid tag, returning the normalized form. An empty raw value yields an
+// empty result with no error, signalling "no tag filter."
+func validateResearchTag(raw string) (string, error) {
+	if raw == "" {
+		return "", nil
+	}
+	n := tag.Normalize(raw)
+	if err := tag.Validate(n); err != nil {
+		return "", fmt.Errorf("invalid --tag %q: %w", raw, err)
+	}
+	return n, nil
+}

--- a/cmd/research_tag_test.go
+++ b/cmd/research_tag_test.go
@@ -1,0 +1,218 @@
+package cmd
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+// TestValidateResearchTag covers the pure helper that normalizes the
+// --tag flag value before research uses it: empty stays empty (no filter),
+// uppercase is lowercased, and an invalid tag returns an error.
+func TestValidateResearchTag(t *testing.T) {
+	cases := []struct {
+		name    string
+		raw     string
+		want    string
+		wantErr bool
+	}{
+		{name: "empty is a no-op", raw: "", want: ""},
+		{name: "lowercase passes through", raw: "infra", want: "infra"},
+		{name: "uppercase is normalized", raw: "INFRA", want: "infra"},
+		{name: "hyphen is allowed", raw: "infra-core", want: "infra-core"},
+		{name: "space rejected", raw: "bad tag", wantErr: true},
+		{name: "punctuation rejected", raw: "bug!", wantErr: true},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := validateResearchTag(tc.raw)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("validateResearchTag(%q) = %q, nil; want error", tc.raw, got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("validateResearchTag(%q) returned unexpected error: %v", tc.raw, err)
+			}
+			if got != tc.want {
+				t.Errorf("validateResearchTag(%q) = %q; want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestResearchCmd_tagFlagInvalidValueErrors verifies that an invalid
+// --tag value (per tag.Validate) is rejected by `worktask research`
+// before any work — no claude run, no writeback. Mirrors the
+// list-command guarantee.
+func TestResearchCmd_tagFlagInvalidValueErrors(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tk := task.Task{
+		ID:      "11111111",
+		Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+		Tags:    []string{"infra"},
+		Body:    "open task\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Cleanup(resetResearchFlags)
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"research", "--tag", "bad tag"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("research --tag 'bad tag': expected error, got nil (stdout=%s)", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "tag") {
+		t.Errorf("error should mention the tag flag; got: %v", err)
+	}
+}
+
+// TestResearchCmd_tagFlagRejectedInSingleMode verifies that `worktask
+// research <fragment> --tag x` errors out clearly rather than silently
+// ignoring --tag — surfacing the user mistake before any agent runs.
+func TestResearchCmd_tagFlagRejectedInSingleMode(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	tk := task.Task{
+		ID:      "11111111",
+		Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+		Tags:    []string{"infra"},
+		Body:    "open task\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	t.Cleanup(resetResearchFlags)
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"research", "11111111", "--tag", "infra"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	err = rootCmd.Execute()
+	if err == nil {
+		t.Fatalf("research <fragment> --tag: expected error, got nil (stdout=%s)", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "single-task") && !strings.Contains(err.Error(), "fragment") {
+		t.Errorf("error should explain that --tag conflicts with single-task mode; got: %v", err)
+	}
+}
+
+// TestResearchCmd_tagFlagFiltersBatchToTaggedTasks verifies that the
+// --tag value is plumbed through to the open-task listing in batch mode:
+// when no open task carries the requested tag, the sweep completes with
+// zero results and zero in every total — proving the filter is applied
+// before the candidate partitioning. (We assert the empty-match path so
+// the test does not need to spawn a real claude runner; if the filter
+// were missing, both planted tasks would reach the runner and the test
+// would hang or fail.)
+func TestResearchCmd_tagFlagFiltersBatchToTaggedTasks(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	planted := []task.Task{
+		{ID: "11111111", Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC), Tags: []string{"infra"}, Body: "first\n"},
+		{ID: "22222222", Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC), Tags: []string{"bug"}, Body: "second\n"},
+	}
+	for _, tk := range planted {
+		raw, err := task.Encode(tk)
+		if err != nil {
+			t.Fatalf("encode: %v", err)
+		}
+		if err := os.WriteFile(filepath.Join(openDir, tk.ID+".md"), raw, 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+	}
+
+	t.Cleanup(resetResearchFlags)
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"research", "--tag", "DOES-NOT-EXIST"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("research --tag: unexpected error: %v (stderr=%s)", err, stderr.String())
+	}
+
+	out := stdout.String()
+	// No task should have been researched: the per-task results array is empty.
+	if !strings.Contains(out, `"results": []`) {
+		t.Errorf("expected empty results array (no task researched), got: %s", out)
+	}
+	// Totals must reflect zero work done.
+	for _, want := range []string{
+		`"findings": 0`,
+		`"clarify": 0`,
+		`"failed": 0`,
+		`"skipped": 0`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("summary should contain %q; full output: %s", want, out)
+		}
+	}
+}
+
+func resetResearchFlags() {
+	researchTag = ""
+	researchAll = false
+	researchStale = 0
+	researchConcurrency = defaultResearchConcurrency
+	researchTimeout = defaultResearchTimeout
+	researchModel = ""
+}

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -194,6 +194,7 @@ Flags:
 - `--concurrency N` (default `3`): max concurrent in-flight research runs in batch mode.
 - `--all`: force re-research of every open task, ignoring `last_researched`.
 - `--stale DURATION`: re-research tasks whose `last_researched` is older than this duration.
+- `--tag TAG` (batch mode only): scope the sweep to open tasks carrying this tag (exact match, lowercased before filtering). Composes as an additional AND with `--all`/`--stale` — tag filter is applied first, then staleness logic runs over the surviving tasks. A non-matching tag yields a normal completion with zero tasks researched. Rejected with an error in single-task mode (when a `<fragment>` is supplied).
 - `--timeout DURATION` (default `10m`): per-task hard timeout.
 - `--model ID`: claude model id; overrides `research_model` from `config.toml`.
 

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -58,7 +58,7 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 1. Invoke via the `Bash` tool with `run_in_background=true`:
    - Single task: `worktask research "<frag>"`
    - Sweep all open tasks (skip already-researched): `worktask research`
-   - Pass through `--all`, `--stale=<dur>`, `--concurrency=N`, `--timeout=<dur>` flags if the user asked for them.
+   - Pass through `--all`, `--stale=<dur>`, `--tag=<tag>`, `--concurrency=N`, `--timeout=<dur>` flags if the user asked for them. `--tag` is batch-mode-only and composes as an additional AND with `--stale`/`--all`.
 2. Reply to the user with an immediate ack (e.g. "queued research on `<frag>`, I'll report when it lands") and stop. Do NOT block, poll, or sleep.
 3. The harness will notify you when the background bash exits. At that point read `BashOutput` for the run.
 4. Parse the **last** JSON object on stdout. Two shapes are possible:


### PR DESCRIPTION
## Summary

- Adds `--tag <tag>` to `worktask research` (batch mode): restricts the sweep to open tasks carrying that tag, applied as an additional AND predicate before the `--stale`/`--all` partitioning.
- Rejects `--tag` in single-task mode (when a `<fragment>` is supplied) with a clear error rather than silently ignoring — surfaces user mistakes early.
- Tag value is normalized via `tag.Normalize` and validated via `tag.Validate` before any work begins; invalid tags fail fast with no agent runs and no writeback.
- Documents the flag in `cli.md` and the vendored slash-command reference in the same PR per the docs-in-band rule.

Closes #80.

## Test plan

- [x] `just ci` passes locally (`fmt-check`, `vet`, `test`, `test-install`).
- [x] `golangci-lint run ./cmd/...` clean.
- [x] `TestValidateResearchTag` covers normalization, hyphen support, and rejection of invalid characters.
- [x] `TestResearchCmd_tagFlagInvalidValueErrors` — `research --tag 'bad tag'` errors before any work.
- [x] `TestResearchCmd_tagFlagRejectedInSingleMode` — `research <fragment> --tag x` errors with a clear single-task-mode message.
- [x] `TestResearchCmd_tagFlagFiltersBatchToTaggedTasks` — planted open tasks with `infra` and `bug` tags + `--tag DOES-NOT-EXIST` → zero results, totals all zero (proves the filter is plumbed; the test would otherwise hang invoking the real runner).

🤖 Generated with [Claude Code](https://claude.com/claude-code)