### PR TITLE
feat(research): land internal/research Coordinator on main

### DIFF
--- a/docs/adr/0002-research-coordinator.md
+++ b/docs/adr/0002-research-coordinator.md
@@ -1,0 +1,226 @@
+# ADR 0002: Research coordinator
+
+## Status
+
+Accepted
+
+## Context
+
+`cmd/research.go` is the apex of the research subsystem: 287 lines that pull
+in nine packages (`config`, `render`, `research/log`, `research/pool`,
+`research/prompt`, `research/runner`, `research/writeback`, `store`, plus
+several stdlib) and stitch them together by hand. Two parallel pipelines
+live in the file — `runSingleResearch` and `runBatchResearch` — and they
+duplicate four steps each: prompt-template loading, log-path
+computation (absolute + relative), `runner.Run` + `writeback.Apply`
+invocation, and rendering.
+
+The duplication is not the worst part. The worst part is `itemMeta`: a
+sidecar map keyed by task ID, defined inside `cmd/`, that exists solely
+because `pool.Item.LogPath` carries the relative path (for display in
+`pool.TaskOutcome`) while `runner.RunInput.LogPath` needs the absolute
+path. The closure that bridges pool and runner reaches into the sidecar
+on every dispatch. The construct is a workaround caused by orchestration
+state living in `cmd/`, above the layer that should own it.
+
+Tracking issue [#85](https://github.com/jvcorredor/worktask/issues/85)
+asked for a research spike: investigate whether a `ResearchCoordinator`
+module — with injected dependencies and a clean test surface — can
+absorb the duplication and dissolve `itemMeta`.
+
+The research subsystem already has the right leaf packages. Each is
+single-purpose and tested at its own level: `prompt` loads and renders,
+`log` computes filenames, `runner` spawns the headless agent and parses
+its output, `pool` runs items in bounded parallel and emits events,
+`writeback` applies side effects to the store. What is missing is an
+apex that composes them.
+
+## Decision
+
+Introduce a top-level `internal/research` package — package name
+`research` — that exposes a `Coordinator` with two methods, `RunOne` and
+`RunBatch`. The leaf subpackages stay where they are. `cmd/research.go`
+shrinks to a thin shell that handles flag parsing, fragment resolution,
+listing/partitioning, signal wiring, and JSON rendering of events and
+outcomes.
+
+### Layering
+
+```
+cmd/research.go         (flags, store lookups, signal handling, render)
+        │
+        ▼
+internal/research       (Coordinator: composes the leaves)
+        │
+        ├─► internal/research/prompt
+        ├─► internal/research/log
+        ├─► internal/research/runner
+        ├─► internal/research/pool
+        └─► internal/research/writeback
+                                 │
+                                 ▼
+                          internal/store
+```
+
+The empty top-level `internal/research/` directory becomes the apex of
+the layered cake. Children name pieces; the parent names the whole
+domain.
+
+### Coordinator interface
+
+The `Coordinator` is a struct with collaborators wired at construction
+and two methods that take pre-resolved inputs.
+
+`RunOne(ctx, t task.Task) (Outcome, error)` runs research on one
+already-resolved task and returns an `Outcome` shaped to match
+`render.ResearchRun` field-for-field.
+
+`RunBatch(ctx, tasks []task.Task, skipped int, opts BatchOpts)
+(<-chan Event, <-chan Summary, error)` mirrors the existing `pool.Run`
+shape: events stream as work happens; one `Summary` lands on `Done` once
+the events channel closes. The skipped count is passed through verbatim
+to `Summary.Totals.Skipped`.
+
+`cmd/` is the input boundary. It resolves fragments to `task.Task`
+(handling user-friendly "did you mean?" hints itself), lists open tasks
+and partitions via `partitionResearchCandidates`, owns
+`signal.NotifyContext`, and pre-resolves the model + extra-tools list
+from flag overrides + config. The Coordinator never touches the
+`config`, `prompt` (other than `prompt.Render`), or `render` packages.
+
+### Injection seams
+
+Three things are injected; everything else is a free-function call.
+
+`RunFunc func(ctx, runner.RunInput) (runner.Result, error)` is the
+runner-shaped seam. Production wires `runner.Run` with `runner.OSExec{}`;
+tests pass a pure in-memory func that returns canned `runner.Result`
+values. We inject one level *above* `runner.Exec` (the seam suggested by
+the spike issue) because `runner.Run` itself does file I/O —
+`os.MkdirAll`, `os.Create`, scanner-buffered stream-json writes — and
+injecting at that level keeps the Coordinator's tests pure in-memory.
+`runner.Run` is unit-tested at its own level; the Coordinator's tests
+verify wiring, not log-file scanning. This precedent already exists in
+`pool`, which injects `pool.RunFunc` for exactly the same reason.
+
+`*store.Store` is injected as a concrete pointer. Tests construct one
+under `t.TempDir()`, matching the pattern in `internal/store/store_test.go`.
+No narrow store interface is introduced — `store` is a one-implementation
+package and YAGNI applies until a second backend ever shows up.
+
+`Clock func() time.Time` is an optional `Option` (defaulting to
+`time.Now().UTC`) so per-task `runStart` timestamps — which determine
+log filenames, frontmatter `last_researched`, and worklog lines — are
+deterministic in tests.
+
+The prompt template is loaded *by `cmd/`* and passed to `New(...)` as a
+string. The Coordinator imports neither the `prompt` package's `Load`
+nor the `config` package; it calls `prompt.Render(template, t)` per
+task. Tests pass a literal template string with no filesystem touch.
+
+### Outcome and event types are owned by the research package
+
+Coordinator returns `research.Outcome`, `research.Event`, and
+`research.Summary` — distinct types defined in the new package, not type
+aliases for or re-exports of `pool.Event` / `pool.TaskOutcome` /
+`pool.Summary`. The internal goroutine that drains pool's events
+translates pool's types into research's types before emitting.
+
+Reasoning: the entire purpose of putting `research` on top of `pool`
+is to give `cmd/` a single orchestration package to depend on. If
+`cmd/` reads `pool.Event` off a `research.Coordinator` channel, the
+new layer is leaky — pool is still part of cmd/'s API surface. Distinct
+types make the boundary real. The cost is one struct copy per event
+per task, which is negligible.
+
+The fields of `research.Event` mirror what `render.ResearchEvent`
+actually consumes — `Type`, `ID`, `Description`, `Started`, `Status`,
+`Summary`, `Err`. `LogPath` and `Tokens` live on `Outcome` and
+`Summary.Results[]`, where the render layer expects them, but not on
+the streamed `Event` (which today's render line schema doesn't carry).
+
+### itemMeta dissolves
+
+The Coordinator builds a private `prepared` map (keyed by task ID) at
+the top of `RunBatch`. Each entry holds the precomputed `pool.Item`,
+the absolute log path, and the per-task `runStart`. The closure passed
+into `pool.Run` looks up its entry by `item.Task.ID` — the same
+structural lookup the cmd-level `itemMeta` did, but no longer crossing
+a package boundary. The map is now legitimate "precomputed per-task
+inputs" owned by the layer that needs them; the workaround status
+disappears.
+
+`pool.Item` is left untouched. Adding `LogPathAbs` to `pool.Item` to
+remove the lookup entirely would re-couple `pool` to filesystem-path
+concerns, against its current "pure orchestration; does not know about
+claude, prompts, log paths, or write-back side effects" docstring. The
+re-coupling is reversible later if it ever proves worthwhile.
+
+### Writeback runs inside the worker closure
+
+`writeback.Apply` is invoked from inside the `RunFunc` closure each
+pool worker calls — after `RunFunc` returns and before the closure
+returns its `runner.Result` back to pool. Concurrency is safe: each
+task's `s.Append` and `s.SetResearchMeta` write to that task's own
+file (different tasks → different files), and `appendWorklog` uses
+`O_APPEND` on a shared file with sub-PIPE_BUF lines, which POSIX
+guarantees atomic across processes.
+
+Doing writeback inside the closure (rather than in a separate
+event-pump goroutine that consumes `pool.Event`s) means the closure
+already has `prepared[item.Task.ID]` in scope — no second map lookup
+in a separate goroutine. It also means that by the time pool emits
+`task_done`, the side effects are committed: the event represents a
+fully-applied result, not a "we're about to write back" promise.
+
+A writeback error becomes a `failed` outcome whose `Summary` is the
+agent's original `result.Summary` and whose `Error` is the writeback
+error message. Status is `failed`. This is a small intentional
+behavior change from today's batch path, which silently swallows
+writeback errors via `_ = writeback.Apply(...)`. See Consequences.
+
+### Per-task render failures don't abort the batch
+
+If `prompt.Render` fails for any task during the prep loop, the
+Coordinator emits a synthetic `task_failed` event for that task,
+records a failed outcome in the summary, and continues with the rest
+of the batch. The current behavior is to return early from
+`runBatchResearch` and abort the whole sweep — also flagged as an
+intentional change in Consequences.
+
+## Consequences
+
+- `cmd/research.go` shrinks dramatically. Most of what it does today
+  becomes a Coordinator concern; what stays is genuinely cmd-shaped:
+  flag parsing, store lookups, signal wiring, JSON rendering.
+- `itemMeta` is no longer a workaround. The same map structure exists
+  one layer down, where it represents normal precomputed state owned by
+  the orchestrator that needs it.
+- The `internal/research` package becomes the only research-facing
+  import for `cmd/`. The leaf subpackages stay public-within-internal so
+  other consumers (none today) can still wire them directly if needed.
+- **Behavior change: writeback errors surface as failed outcomes.**
+  The current batch path silently swallows them; the new path turns
+  them into `failed` results so a "research run reported success but
+  the task body wasn't updated" silently doesn't happen. Single-task
+  callers (`worktask research <fragment>`) see the writeback error
+  reflected in the JSON line's `error` field.
+- **Behavior change: per-task render failures no longer abort the
+  batch.** A malformed body that breaks the template for one task no
+  longer poisons the other 49. The failing task lands in the summary
+  as a failed outcome with the render error.
+- The Coordinator's tests stay pure in-memory because `RunFunc` is the
+  injection seam. `runner.Run` continues to be tested at its own level.
+- The leaf packages — `prompt`, `log`, `runner`, `pool`, `writeback` —
+  are unchanged. The spike does not touch their interfaces.
+
+## References
+
+- Spike issue: [#85](https://github.com/jvcorredor/worktask/issues/85)
+- Prototype branch: `worktask-85-research-coordinator-spike` —
+  contains the Coordinator package and three indicative tests
+  (`TestRunOne_findings_appliesWriteback`,
+  `TestRunOne_failed_skipsWriteback`,
+  `TestRunBatch_mixedOutcomes_emitsEventsAndAppliesWritebackPerStatus`).
+  The branch does *not* yet rewrite `cmd/research.go`; that
+  extraction is a follow-up that consumes this prototype.

--- a/internal/research/research.go
+++ b/internal/research/research.go
@@ -1,0 +1,445 @@
+// Package research is the top-level orchestration layer for headless
+// research runs. It composes the leaf subpackages — prompt, log,
+// runner, pool, writeback — and exposes a [Coordinator] with two
+// methods: [Coordinator.RunOne] for a single task and
+// [Coordinator.RunBatch] for a streaming batch.
+//
+// Inputs are pre-resolved at the cmd boundary: callers hand in the
+// already-loaded prompt template, already-resolved [task.Task] values,
+// and a runner-shaped [RunFunc] seam so tests stay pure in-memory.
+// The package itself imports neither config nor render.
+//
+// See docs/adr/0002-research-coordinator.md for the design rationale.
+package research
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"strings"
+	"sync"
+	"time"
+
+	researchlog "github.com/jvcorredor/worktask/internal/research/log"
+	"github.com/jvcorredor/worktask/internal/research/pool"
+	"github.com/jvcorredor/worktask/internal/research/prompt"
+	"github.com/jvcorredor/worktask/internal/research/runner"
+	"github.com/jvcorredor/worktask/internal/research/writeback"
+	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+// RunFunc is the runner-shaped seam the [Coordinator] depends on.
+// Production wires [runner.Run] with [runner.OSExec]; tests inject a
+// func that returns canned [runner.Result] values without touching the
+// filesystem.
+type RunFunc func(ctx context.Context, in runner.RunInput) (runner.Result, error)
+
+// Config carries the fully-resolved settings the [Coordinator] needs.
+// All values are pre-resolved at the cmd boundary — Model and
+// ExtraTools have already absorbed flag overrides, and the prompt
+// template is loaded from disk and passed to [New] separately.
+type Config struct {
+	// TasksDir is the absolute path to the worktask tasks directory.
+	// Used by [researchlog.Path] to build per-task log filenames.
+	TasksDir string
+	// WorkingLogPath is the absolute path of the worklog file the
+	// writeback layer appends "research:" lines to. Empty disables
+	// the worklog append.
+	WorkingLogPath string
+	// Model is the resolved model id passed to the runner. The cmd
+	// layer applies --model > config.research_model precedence before
+	// constructing the Coordinator.
+	Model string
+	// ExtraTools is the resolved, pre-validated extra-tools list passed
+	// to the runner. Validation happens in the config package; by the
+	// time it lands here it is known-clean.
+	ExtraTools []string
+}
+
+// Option is a functional option for [New].
+type Option func(*Coordinator)
+
+// WithClock injects a clock function. Tests use this to make per-task
+// run-start times — and therefore log filenames, frontmatter
+// last_researched, and worklog line timestamps — deterministic.
+// Defaults to time.Now in UTC.
+func WithClock(clock func() time.Time) Option {
+	return func(c *Coordinator) { c.clock = clock }
+}
+
+// Coordinator orchestrates one research run ([Coordinator.RunOne]) or
+// one batch ([Coordinator.RunBatch]). Collaborators are wired at
+// construction time. A Coordinator instance is intended to live for
+// the duration of one CLI invocation; reuse across invocations is
+// safe but unnecessary.
+type Coordinator struct {
+	store    *store.Store
+	run      RunFunc
+	cfg      Config
+	template string
+	clock    func() time.Time
+}
+
+// New constructs a Coordinator. The template is the loaded prompt
+// template body — the cmd layer is responsible for reading it from
+// disk via [prompt.Load] before calling New, so the Coordinator never
+// imports the prompt-load path. The error return is reserved for
+// future construction-time validation; today New does not fail.
+func New(s *store.Store, run RunFunc, cfg Config, template string, opts ...Option) (*Coordinator, error) {
+	c := &Coordinator{
+		store:    s,
+		run:      run,
+		cfg:      cfg,
+		template: template,
+		clock:    func() time.Time { return time.Now().UTC() },
+	}
+	for _, opt := range opts {
+		opt(c)
+	}
+	return c, nil
+}
+
+// Outcome is the result of one [Coordinator.RunOne] call, shaped to
+// map field-by-field onto render.ResearchRun at the cmd layer.
+type Outcome struct {
+	ID          string
+	Description string
+	Status      string
+	Summary     string
+	LogPath     string // relative to Config.TasksDir
+	Tokens      int
+	Error       string // populated on failed status
+}
+
+// Event is one streaming progress event emitted by
+// [Coordinator.RunBatch]. Field shape matches render.ResearchEvent.
+type Event struct {
+	Type        string // "task_started" | "task_done" | "task_failed"
+	ID          string
+	Description string    // populated on task_started
+	Started     time.Time // populated on task_started
+	Status      string    // populated on task_done
+	Summary     string    // populated on task_done
+	Err         error     // populated on task_failed
+}
+
+// Totals counts per-status outcomes plus the skipped-at-prep count.
+type Totals struct {
+	Findings, Clarify, Failed, Skipped int
+}
+
+// Summary is the final aggregate emitted on the Done channel after
+// [Coordinator.RunBatch] drains.
+type Summary struct {
+	BatchID  string
+	Started  time.Time
+	Finished time.Time
+	Results  []Outcome
+	Totals   Totals
+}
+
+// BatchOpts configures one [Coordinator.RunBatch] invocation.
+type BatchOpts struct {
+	// Concurrency caps in-flight workers. Values below 1 are clamped
+	// to 1 by the underlying pool.
+	Concurrency int
+	// Timeout is the per-task hard timeout. Zero disables.
+	Timeout time.Duration
+}
+
+// RunOne runs research on a single resolved task. The body is rendered
+// against the loaded template, the runner is invoked, and on a
+// non-failed status writeback is applied (Research section appended,
+// research-meta frontmatter set, worklog line appended). The returned
+// Outcome maps field-by-field onto render.ResearchRun.
+//
+// A runner error becomes a failed Outcome carrying the error message;
+// a writeback error after a non-failed run also becomes a failed
+// Outcome — see ADR 0002 Consequences.
+func (c *Coordinator) RunOne(ctx context.Context, t task.Task) (Outcome, error) {
+	desc := firstLine(t.Body)
+
+	rendered, err := prompt.Render(c.template, t)
+	if err != nil {
+		return Outcome{
+			ID:          t.ID,
+			Description: desc,
+			Status:      "failed",
+			Summary:     err.Error(),
+			Error:       err.Error(),
+		}, nil
+	}
+
+	runStart := c.clock()
+	logPath := researchlog.Path(c.cfg.TasksDir, t.ID, runStart)
+	logPathRel := relPath(c.cfg.TasksDir, logPath)
+
+	result, runErr := c.run(ctx, runner.RunInput{
+		Prompt:     rendered,
+		LogPath:    logPath,
+		Model:      c.cfg.Model,
+		ExtraTools: c.cfg.ExtraTools,
+	})
+	if runErr != nil {
+		result = runner.Result{
+			Status:  "failed",
+			Summary: runErr.Error(),
+		}
+	}
+
+	if wbErr := c.writeBack(t.ID, result, runStart, logPath, logPathRel); wbErr != nil {
+		return Outcome{
+			ID:          t.ID,
+			Description: desc,
+			Status:      "failed",
+			Summary:     result.Summary,
+			LogPath:     logPathRel,
+			Tokens:      result.Tokens,
+			Error:       wbErr.Error(),
+		}, nil
+	}
+
+	out := Outcome{
+		ID:          t.ID,
+		Description: desc,
+		Status:      result.Status,
+		Summary:     result.Summary,
+		LogPath:     logPathRel,
+		Tokens:      result.Tokens,
+	}
+	if result.Status == "failed" {
+		out.Error = errString(runErr)
+	}
+	return out, nil
+}
+
+// preparedItem holds per-task inputs precomputed at the top of RunBatch.
+// The map of these — keyed by task ID — is the legitimate internal
+// state that subsumes the cmd-level itemMeta workaround (see ADR 0002).
+type preparedItem struct {
+	item       pool.Item
+	absLogPath string
+	runStart   time.Time
+	desc       string
+	renderErr  error // when non-nil, the task short-circuits to a failed outcome before pool sees it
+}
+
+// writebackFailure captures the agent's original summary and the
+// writeback error message for one task whose post-run writeback failed.
+// RunBatch consults this map after pool drains so the final Outcome
+// preserves the agent's summary in Outcome.Summary while surfacing the
+// writeback error via Outcome.Error.
+type writebackFailure struct {
+	originalSummary string
+	originalTokens  int
+	errMsg          string
+}
+
+// RunBatch runs research over a slice of pre-partitioned open tasks
+// and returns two channels: a streaming Events channel that closes
+// when work drains, and a Done channel that receives exactly one
+// Summary after Events closes. The skipped count is forwarded
+// verbatim to Summary.Totals.Skipped.
+//
+// Per-task failure modes:
+//   - prompt.Render failure during prep: a task_failed event is
+//     emitted with the render error; the task lands as a failed
+//     outcome in the summary; other tasks continue. (Behavior change
+//     from the prior cmd-level batch path; see ADR 0002.)
+//   - RunFunc error: surfaced as task_failed by the underlying pool.
+//   - writeback error after a non-failed run: turned into a failed
+//     outcome that preserves the agent's original Summary and surfaces
+//     the writeback error message via Outcome.Error. (Behavior change.)
+//
+// The caller owns ctx lifetime — wire signal.NotifyContext at the
+// cmd boundary if SIGINT/SIGTERM cancel is desired.
+func (c *Coordinator) RunBatch(ctx context.Context, tasks []task.Task, skipped int, opts BatchOpts) (<-chan Event, <-chan Summary, error) {
+	prepared := make(map[string]preparedItem, len(tasks))
+	items := make([]pool.Item, 0, len(tasks))
+	var prepFailures []preparedItem
+	var (
+		wbMu       sync.Mutex
+		wbFailures = make(map[string]writebackFailure)
+	)
+
+	for _, t := range tasks {
+		runStart := c.clock()
+		logPath := researchlog.Path(c.cfg.TasksDir, t.ID, runStart)
+		logPathRel := relPath(c.cfg.TasksDir, logPath)
+		desc := firstLine(t.Body)
+
+		rendered, rerr := prompt.Render(c.template, t)
+		if rerr != nil {
+			prepFailures = append(prepFailures, preparedItem{
+				item:       pool.Item{Task: t, LogPath: logPathRel},
+				absLogPath: logPath,
+				runStart:   runStart,
+				desc:       desc,
+				renderErr:  rerr,
+			})
+			continue
+		}
+		item := pool.Item{
+			Task:    t,
+			Prompt:  rendered,
+			LogPath: logPathRel,
+		}
+		prepared[t.ID] = preparedItem{
+			item:       item,
+			absLogPath: logPath,
+			runStart:   runStart,
+			desc:       desc,
+		}
+		items = append(items, item)
+	}
+
+	runFn := func(ctx context.Context, item pool.Item) (runner.Result, error) {
+		p := prepared[item.Task.ID]
+		result, runErr := c.run(ctx, runner.RunInput{
+			Prompt:     item.Prompt,
+			LogPath:    p.absLogPath,
+			Model:      c.cfg.Model,
+			ExtraTools: c.cfg.ExtraTools,
+		})
+		if runErr != nil {
+			return result, runErr
+		}
+		if wbErr := c.writeBack(item.Task.ID, result, p.runStart, p.absLogPath, item.LogPath); wbErr != nil {
+			wbMu.Lock()
+			wbFailures[item.Task.ID] = writebackFailure{
+				originalSummary: result.Summary,
+				originalTokens:  result.Tokens,
+				errMsg:          wbErr.Error(),
+			}
+			wbMu.Unlock()
+			return result, fmt.Errorf("writeback: %w", wbErr)
+		}
+		return result, nil
+	}
+
+	poolRes := pool.Run(ctx, items, runFn, pool.Opts{
+		Concurrency: opts.Concurrency,
+		Timeout:     opts.Timeout,
+	})
+
+	events := make(chan Event)
+	done := make(chan Summary, 1)
+
+	go func() {
+		defer close(events)
+		// Synthetic prep-failure events ride the same channel ahead of
+		// pool's events. Order across the boundary is "all prep failures
+		// first, then live pool events as they happen."
+		for _, p := range prepFailures {
+			events <- Event{
+				Type:        "task_failed",
+				ID:          p.item.Task.ID,
+				Description: p.desc,
+				Started:     p.runStart,
+				Err:         p.renderErr,
+			}
+		}
+		for ev := range poolRes.Events {
+			events <- translateEvent(ev)
+		}
+	}()
+
+	go func() {
+		poolSummary := <-poolRes.Done
+		s := Summary{
+			BatchID:  poolSummary.BatchID,
+			Started:  poolSummary.Started,
+			Finished: poolSummary.Finished,
+			Totals: Totals{
+				Findings: poolSummary.Totals.Findings,
+				Clarify:  poolSummary.Totals.Clarify,
+				Failed:   poolSummary.Totals.Failed,
+				Skipped:  skipped,
+			},
+		}
+		for _, p := range prepFailures {
+			s.Results = append(s.Results, Outcome{
+				ID:          p.item.Task.ID,
+				Description: p.desc,
+				Status:      "failed",
+				Summary:     p.renderErr.Error(),
+				LogPath:     p.item.LogPath,
+				Error:       p.renderErr.Error(),
+			})
+			s.Totals.Failed++
+		}
+		for _, r := range poolSummary.Results {
+			out := Outcome{
+				ID:          r.ID,
+				Description: r.Description,
+				Status:      r.Status,
+				Summary:     r.Summary,
+				LogPath:     r.LogPath,
+				Tokens:      r.Tokens,
+				Error:       r.Error,
+			}
+			if wb, ok := wbFailures[r.ID]; ok {
+				out.Summary = wb.originalSummary
+				out.Tokens = wb.originalTokens
+				out.Error = wb.errMsg
+			}
+			s.Results = append(s.Results, out)
+		}
+		done <- s
+		close(done)
+	}()
+
+	return events, done, nil
+}
+
+func (c *Coordinator) writeBack(fragment string, result runner.Result, runStart time.Time, logPath, logPathRel string) error {
+	return writeback.Apply(c.store, writeback.Input{
+		Fragment:       fragment,
+		Result:         result,
+		RunStart:       runStart,
+		LogPath:        logPath,
+		LogPathRel:     logPathRel,
+		WorkingLogPath: c.cfg.WorkingLogPath,
+	})
+}
+
+func translateEvent(ev pool.Event) Event {
+	e := Event{
+		Type:        ev.Type,
+		ID:          ev.Task.ID,
+		Description: firstLine(ev.Task.Body),
+		Started:     ev.Started,
+	}
+	switch ev.Type {
+	case "task_done":
+		e.Status = ev.Result.Status
+		e.Summary = ev.Result.Summary
+	case "task_failed":
+		e.Err = ev.Err
+	}
+	return e
+}
+
+func relPath(base, target string) string {
+	rel, err := filepath.Rel(base, target)
+	if err != nil {
+		return target
+	}
+	return rel
+}
+
+func firstLine(body string) string {
+	body = strings.TrimRight(body, "\n")
+	if i := strings.IndexByte(body, '\n'); i >= 0 {
+		return body[:i]
+	}
+	return body
+}
+
+func errString(err error) string {
+	if err == nil {
+		return ""
+	}
+	return err.Error()
+}

--- a/internal/research/research_test.go
+++ b/internal/research/research_test.go
@@ -1,0 +1,540 @@
+package research
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jvcorredor/worktask/internal/research/runner"
+	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+const fixedTemplate = "Research the following task:\n\n{{.Body}}"
+
+func TestRunOne_findings_appliesWriteback(t *testing.T) {
+	dir := t.TempDir()
+	worklog := filepath.Join(dir, "worklog.md")
+	s := newStore(t, dir)
+
+	added, err := s.Add("buy milk")
+	if err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog, Model: "claude-sonnet-4-6"}
+
+	var gotInput runner.RunInput
+	run := func(_ context.Context, in runner.RunInput) (runner.Result, error) {
+		gotInput = in
+		return runner.Result{
+			Status:  "findings",
+			Summary: "got context",
+			Body:    "Detailed findings here.",
+			Tokens:  1234,
+		}, nil
+	}
+
+	c, err := New(s, run, cfg, fixedTemplate, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := c.RunOne(context.Background(), added)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+
+	if out.Status != "findings" {
+		t.Errorf("Outcome.Status = %q; want findings", out.Status)
+	}
+	if out.Summary != "got context" {
+		t.Errorf("Outcome.Summary = %q; want %q", out.Summary, "got context")
+	}
+	if out.Tokens != 1234 {
+		t.Errorf("Outcome.Tokens = %d; want 1234", out.Tokens)
+	}
+	if out.Error != "" {
+		t.Errorf("Outcome.Error = %q; want empty on findings", out.Error)
+	}
+
+	wantLogRel := filepath.Join("research-logs", added.ID+"_2026-05-03T12-00-00.jsonl")
+	if out.LogPath != wantLogRel {
+		t.Errorf("Outcome.LogPath = %q; want %q", out.LogPath, wantLogRel)
+	}
+	wantPrompt := "Research the following task:\n\nbuy milk\n"
+	if gotInput.Prompt != wantPrompt {
+		t.Errorf("RunFunc.Prompt = %q; want %q", gotInput.Prompt, wantPrompt)
+	}
+	if !strings.HasSuffix(gotInput.LogPath, wantLogRel) {
+		t.Errorf("RunFunc.LogPath = %q; want suffix %q", gotInput.LogPath, wantLogRel)
+	}
+	if gotInput.Model != "claude-sonnet-4-6" {
+		t.Errorf("RunFunc.Model = %q; want claude-sonnet-4-6", gotInput.Model)
+	}
+
+	reread, _, _, err := s.Get(added.ID)
+	if err != nil {
+		t.Fatalf("Get after writeback: %v", err)
+	}
+	if !reread.LastResearched.Equal(clock.times[0]) {
+		t.Errorf("LastResearched = %v; want %v", reread.LastResearched, clock.times[0])
+	}
+	if reread.LastResearchLog != wantLogRel {
+		t.Errorf("LastResearchLog = %q; want %q", reread.LastResearchLog, wantLogRel)
+	}
+	if !strings.Contains(reread.Body, "## Research 2026-05-03T12:00:00Z") {
+		t.Errorf("body missing Research section header; got:\n%s", reread.Body)
+	}
+	if !strings.Contains(reread.Body, "Detailed findings here.") {
+		t.Errorf("body missing rendered findings body; got:\n%s", reread.Body)
+	}
+
+	wlBytes, err := os.ReadFile(worklog)
+	if err != nil {
+		t.Fatalf("worklog read: %v", err)
+	}
+	if !strings.Contains(string(wlBytes), "research: got context") {
+		t.Errorf("worklog missing summary line; got:\n%s", string(wlBytes))
+	}
+}
+
+func TestRunOne_failed_skipsWriteback(t *testing.T) {
+	dir := t.TempDir()
+	worklog := filepath.Join(dir, "worklog.md")
+	s := newStore(t, dir)
+
+	added, err := s.Add("debug login")
+	if err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+	bodyBefore := added.Body
+	lastBefore := added.LastResearched
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog}
+
+	run := func(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+		return runner.Result{}, errors.New("claude exited 1")
+	}
+
+	c, err := New(s, run, cfg, fixedTemplate, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := c.RunOne(context.Background(), added)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+
+	if out.Status != "failed" {
+		t.Errorf("Outcome.Status = %q; want failed", out.Status)
+	}
+	if out.Error == "" {
+		t.Errorf("Outcome.Error empty; want runner error message")
+	}
+	if !strings.Contains(out.Summary, "claude exited 1") {
+		t.Errorf("Outcome.Summary = %q; want it to contain runner error", out.Summary)
+	}
+
+	got, _, _, err := s.Get(added.ID)
+	if err != nil {
+		t.Fatalf("Get after failed run: %v", err)
+	}
+	if got.Body != bodyBefore {
+		t.Errorf("body changed on failed run:\nbefore=%q\nafter =%q", bodyBefore, got.Body)
+	}
+	if !got.LastResearched.Equal(lastBefore) {
+		t.Errorf("LastResearched changed on failed run: before=%v after=%v", lastBefore, got.LastResearched)
+	}
+	if got.LastResearchLog != "" {
+		t.Errorf("LastResearchLog populated on failed run: %q", got.LastResearchLog)
+	}
+	if _, err := os.Stat(worklog); !errors.Is(err, os.ErrNotExist) {
+		t.Errorf("worklog should not exist after failed run; stat err = %v", err)
+	}
+}
+
+func TestRunBatch_mixedOutcomes_emitsEventsAndAppliesWritebackPerStatus(t *testing.T) {
+	dir := t.TempDir()
+	worklog := filepath.Join(dir, "worklog.md")
+	s := newStore(t, dir)
+
+	a, err := s.Add("alpha task")
+	if err != nil {
+		t.Fatalf("seed Add a: %v", err)
+	}
+	b, err := s.Add("beta task")
+	if err != nil {
+		t.Fatalf("seed Add b: %v", err)
+	}
+	bBodyBefore := b.Body
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog}
+
+	run := func(_ context.Context, in runner.RunInput) (runner.Result, error) {
+		switch {
+		case strings.Contains(in.Prompt, "alpha"):
+			return runner.Result{
+				Status:  "findings",
+				Summary: "alpha summary",
+				Body:    "alpha body",
+				Tokens:  10,
+			}, nil
+		case strings.Contains(in.Prompt, "beta"):
+			return runner.Result{}, errors.New("beta blew up")
+		}
+		t.Fatalf("unexpected prompt: %q", in.Prompt)
+		return runner.Result{}, nil
+	}
+
+	c, err := New(s, run, cfg, fixedTemplate, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	events, done, err := c.RunBatch(
+		context.Background(),
+		[]task.Task{a, b},
+		2, // arbitrary skipped count
+		BatchOpts{Concurrency: 2, Timeout: time.Second},
+	)
+	if err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+
+	gotEvents := map[string]map[string]Event{} // id -> type -> event
+	for ev := range events {
+		if gotEvents[ev.ID] == nil {
+			gotEvents[ev.ID] = map[string]Event{}
+		}
+		gotEvents[ev.ID][ev.Type] = ev
+	}
+	summary := <-done
+
+	if _, ok := gotEvents[a.ID]["task_started"]; !ok {
+		t.Errorf("missing task_started event for alpha (id=%s)", a.ID)
+	}
+	if e, ok := gotEvents[a.ID]["task_done"]; !ok {
+		t.Errorf("missing task_done event for alpha (id=%s)", a.ID)
+	} else {
+		if e.Status != "findings" {
+			t.Errorf("alpha task_done.Status = %q; want findings", e.Status)
+		}
+		if e.Summary != "alpha summary" {
+			t.Errorf("alpha task_done.Summary = %q; want alpha summary", e.Summary)
+		}
+	}
+
+	if _, ok := gotEvents[b.ID]["task_started"]; !ok {
+		t.Errorf("missing task_started event for beta (id=%s)", b.ID)
+	}
+	if e, ok := gotEvents[b.ID]["task_failed"]; !ok {
+		t.Errorf("missing task_failed event for beta (id=%s)", b.ID)
+	} else if e.Err == nil || !strings.Contains(e.Err.Error(), "beta blew up") {
+		t.Errorf("beta task_failed.Err = %v; want it to mention runner error", e.Err)
+	}
+
+	wantTotals := Totals{Findings: 1, Failed: 1, Skipped: 2}
+	if summary.Totals != wantTotals {
+		t.Errorf("Summary.Totals = %+v; want %+v", summary.Totals, wantTotals)
+	}
+	if len(summary.Results) != 2 {
+		t.Errorf("len(Summary.Results) = %d; want 2", len(summary.Results))
+	}
+
+	gotA, _, _, err := s.Get(a.ID)
+	if err != nil {
+		t.Fatalf("Get alpha: %v", err)
+	}
+	if !strings.Contains(gotA.Body, "alpha body") {
+		t.Errorf("alpha body missing writeback section; got:\n%s", gotA.Body)
+	}
+	if gotA.LastResearched.IsZero() {
+		t.Errorf("alpha LastResearched not set after writeback")
+	}
+
+	gotB, _, _, err := s.Get(b.ID)
+	if err != nil {
+		t.Fatalf("Get beta: %v", err)
+	}
+	if gotB.Body != bBodyBefore {
+		t.Errorf("beta body changed despite failed run:\nbefore=%q\nafter =%q", bBodyBefore, gotB.Body)
+	}
+	if !gotB.LastResearched.IsZero() {
+		t.Errorf("beta LastResearched populated despite failed run: %v", gotB.LastResearched)
+	}
+
+	wlBytes, _ := os.ReadFile(worklog)
+	if !strings.Contains(string(wlBytes), "research: alpha summary") {
+		t.Errorf("worklog missing alpha summary; got:\n%s", string(wlBytes))
+	}
+	if strings.Contains(string(wlBytes), "research: beta") {
+		t.Errorf("worklog should not contain beta entry on failed run; got:\n%s", string(wlBytes))
+	}
+}
+
+func TestRunOne_writebackError_preservesSummary(t *testing.T) {
+	dir := t.TempDir()
+	// Create a regular file at the path appendWorklog would treat as a
+	// directory parent. os.MkdirAll inside appendWorklog then fails,
+	// which forces writeback.Apply to return a non-nil error after the
+	// body section and frontmatter have already been written.
+	blocker := filepath.Join(dir, "blocker")
+	if err := os.WriteFile(blocker, []byte("not a directory"), 0o644); err != nil {
+		t.Fatalf("seed blocker file: %v", err)
+	}
+	worklog := filepath.Join(blocker, "worklog.md")
+
+	s := newStore(t, dir)
+	added, err := s.Add("buy milk")
+	if err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog}
+
+	const agentSummary = "got context"
+	run := func(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+		return runner.Result{
+			Status:  "findings",
+			Summary: agentSummary,
+			Body:    "Detailed findings here.",
+			Tokens:  1234,
+		}, nil
+	}
+
+	c, err := New(s, run, cfg, fixedTemplate, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	out, err := c.RunOne(context.Background(), added)
+	if err != nil {
+		t.Fatalf("RunOne: %v", err)
+	}
+
+	if out.Status != "failed" {
+		t.Errorf("Outcome.Status = %q; want failed", out.Status)
+	}
+	if out.Summary != agentSummary {
+		t.Errorf("Outcome.Summary = %q; want %q (agent's original summary preserved)", out.Summary, agentSummary)
+	}
+	if out.Error == "" {
+		t.Errorf("Outcome.Error empty; want writeback error message")
+	}
+	if !strings.Contains(out.Error, "writeback") {
+		t.Errorf("Outcome.Error = %q; want it to identify the writeback failure", out.Error)
+	}
+}
+
+func TestRunBatch_renderFailure_doesNotAbortBatch(t *testing.T) {
+	dir := t.TempDir()
+	worklog := filepath.Join(dir, "worklog.md")
+	s := newStore(t, dir)
+
+	// Custom template references .Tags[0]; rendering fails at execute
+	// time for any task whose Tags slice is empty. badTask has no tags;
+	// goodTask has one. The failure is per-task, not per-batch.
+	const tmpl = "Research: {{.Body}}{{index .Tags 0}}"
+
+	badTask, err := s.Add("malformed task")
+	if err != nil {
+		t.Fatalf("seed bad task: %v", err)
+	}
+	goodTask, err := s.Add("healthy task", "x")
+	if err != nil {
+		t.Fatalf("seed good task: %v", err)
+	}
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog}
+
+	var ranIDs []string
+	run := func(_ context.Context, in runner.RunInput) (runner.Result, error) {
+		ranIDs = append(ranIDs, in.Prompt) // capture which prompts the runner saw
+		return runner.Result{
+			Status:  "findings",
+			Summary: "good summary",
+			Body:    "good body",
+		}, nil
+	}
+
+	c, err := New(s, run, cfg, tmpl, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	events, done, err := c.RunBatch(
+		context.Background(),
+		[]task.Task{badTask, goodTask},
+		0,
+		BatchOpts{Concurrency: 2, Timeout: time.Second},
+	)
+	if err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+
+	gotEvents := map[string]map[string]Event{}
+	for ev := range events {
+		if gotEvents[ev.ID] == nil {
+			gotEvents[ev.ID] = map[string]Event{}
+		}
+		gotEvents[ev.ID][ev.Type] = ev
+	}
+	summary := <-done
+
+	failedEv, ok := gotEvents[badTask.ID]["task_failed"]
+	if !ok {
+		t.Fatalf("missing synthetic task_failed event for bad task (id=%s); got events=%+v", badTask.ID, gotEvents)
+	}
+	if failedEv.Err == nil {
+		t.Errorf("task_failed.Err = nil; want render error")
+	}
+
+	if _, ok := gotEvents[goodTask.ID]["task_started"]; !ok {
+		t.Errorf("missing task_started for good task (id=%s); other tasks must still run", goodTask.ID)
+	}
+	if doneEv, ok := gotEvents[goodTask.ID]["task_done"]; !ok {
+		t.Errorf("missing task_done for good task (id=%s); other tasks must still run", goodTask.ID)
+	} else if doneEv.Status != "findings" {
+		t.Errorf("good task_done.Status = %q; want findings", doneEv.Status)
+	}
+
+	if len(ranIDs) != 1 {
+		t.Errorf("runner invoked %d times; want exactly 1 (only the good task)", len(ranIDs))
+	}
+
+	if len(summary.Results) != 2 {
+		t.Errorf("len(Summary.Results) = %d; want 2 (one failed + one findings)", len(summary.Results))
+	}
+	var foundBadFailed bool
+	for _, r := range summary.Results {
+		if r.ID == badTask.ID {
+			foundBadFailed = true
+			if r.Status != "failed" {
+				t.Errorf("bad task Status = %q; want failed", r.Status)
+			}
+			if r.Error == "" {
+				t.Errorf("bad task Error empty; want render error string")
+			}
+		}
+	}
+	if !foundBadFailed {
+		t.Errorf("Summary.Results missing failed outcome for bad task")
+	}
+	if summary.Totals.Failed != 1 {
+		t.Errorf("Totals.Failed = %d; want 1", summary.Totals.Failed)
+	}
+	if summary.Totals.Findings != 1 {
+		t.Errorf("Totals.Findings = %d; want 1", summary.Totals.Findings)
+	}
+}
+
+func TestRunBatch_skippedCount_forwardedVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	worklog := filepath.Join(dir, "worklog.md")
+	s := newStore(t, dir)
+
+	added, err := s.Add("only task")
+	if err != nil {
+		t.Fatalf("seed Add: %v", err)
+	}
+
+	clock := fixedClock(2026, 5, 3, 12, 0, 0)
+	cfg := Config{TasksDir: dir, WorkingLogPath: worklog}
+
+	run := func(_ context.Context, _ runner.RunInput) (runner.Result, error) {
+		return runner.Result{
+			Status:  "findings",
+			Summary: "summary",
+			Body:    "body",
+		}, nil
+	}
+
+	c, err := New(s, run, cfg, fixedTemplate, WithClock(clock.Now))
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+
+	const skipped = 7
+	events, done, err := c.RunBatch(
+		context.Background(),
+		[]task.Task{added},
+		skipped,
+		BatchOpts{Concurrency: 1, Timeout: time.Second},
+	)
+	if err != nil {
+		t.Fatalf("RunBatch: %v", err)
+	}
+	for range events {
+	}
+	summary := <-done
+
+	if summary.Totals.Skipped != skipped {
+		t.Errorf("Summary.Totals.Skipped = %d; want %d (forwarded verbatim from caller)", summary.Totals.Skipped, skipped)
+	}
+}
+
+// --- helpers ---
+
+func newStore(t *testing.T, dir string) *store.Store {
+	t.Helper()
+	s := store.New(dir)
+	// Pin Now and NewID for stable test output.
+	idCounter := 0
+	s.NewID = func() string {
+		idCounter++
+		// Eight-char hex-ish IDs, distinct across calls in one test.
+		return string([]byte{
+			'a' + byte(idCounter%26),
+			'a' + byte((idCounter/26)%26),
+			'b', 'c', 'd', 'e', 'f', '0',
+		})
+	}
+	addCounter := 0
+	s.Now = func() time.Time {
+		addCounter++
+		return time.Date(2026, 4, 1, 9, addCounter, 0, 0, time.UTC)
+	}
+	return s
+}
+
+type sequenceClock struct {
+	times []time.Time
+	idx   int
+}
+
+func (c *sequenceClock) Now() time.Time {
+	if c.idx >= len(c.times) {
+		// Once exhausted, keep returning the last time. Tests should
+		// configure enough clock ticks to cover the run.
+		return c.times[len(c.times)-1]
+	}
+	t := c.times[c.idx]
+	c.idx++
+	return t
+}
+
+// fixedClock returns a clock that emits one fixed time. RunOne calls
+// the clock once; RunBatch calls it once per task during prep. Tests
+// that need distinct per-task times should build a clock with multiple
+// entries inline.
+func fixedClock(year int, mo time.Month, day, h, m, s int) *sequenceClock {
+	return &sequenceClock{
+		times: []time.Time{
+			time.Date(year, mo, day, h, m, s, 0, time.UTC),
+			time.Date(year, mo, day, h, m, s+1, 0, time.UTC),
+			time.Date(year, mo, day, h, m, s+2, 0, time.UTC),
+			time.Date(year, mo, day, h, m, s+3, 0, time.UTC),
+		},
+	}
+}


### PR DESCRIPTION
## Summary

- Promote the `internal/research` Coordinator package from the spike branch (`worktask-85-research-coordinator-spike`) onto `main`, with the writeback-error path refined so failures preserve the agent's original `result.Summary` in `Outcome.Summary` and surface the writeback error string via `Outcome.Error` (status remains `failed`). Applied uniformly to `RunOne` and the `RunBatch` worker closure.
- Extend the test suite from three to six: add `TestRunOne_writebackError_preservesSummary`, `TestRunBatch_renderFailure_doesNotAbortBatch`, and `TestRunBatch_skippedCount_forwardedVerbatim`.
- Flip `docs/adr/0002-research-coordinator.md` Status from `Proposed` to `Accepted`; align its writeback-error wording with shipped behavior.
- No `cmd/` changes, no leaf-subpackage changes — the package compiles, is fully tested, and is not yet wired into the CLI.

Closes: #95
Refs: #94

## Test plan

- [x] `just ci` green (vet, tests, install, version smoke)
- [x] `golangci-lint run ./...` — 0 issues
- [x] All six Coordinator tests pass: the three from the spike plus the three new ones
- [x] All Coordinator tests run in-memory via injected `RunFunc` — no `claude` binary invoked
- [x] `git diff main -- cmd/ internal/research/{prompt,log,runner,pool,writeback}` is empty (leaf packages and cmd untouched)

🤖 Generated with [Claude Code](https://claude.com/claude-code)