### PR TITLE
feat(show): emit last_researched and last_research_log in JSON

### DIFF
--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -24,7 +24,7 @@ Pass `--format=json` to any subcommand to get machine-readable output. The schem
 
 `completed` is omitted on open tasks.
 
-`show` returns the same fields plus `body` (the full body string after the first description line) and `path` (the absolute, cleaned filesystem path of the task file; symlinks in the configured tasks directory are preserved verbatim).
+`show` returns the same fields plus `body` (the full body string after the first description line) and `path` (the absolute, cleaned filesystem path of the task file; symlinks in the configured tasks directory are preserved verbatim). Two optional research fields are emitted only when the task has been researched: `last_researched` (RFC 3339 timestamp in UTC) and `last_research_log` (absolute path to the research log file). Both mirror the YAML frontmatter keys and are omitted when empty.
 
 Golden fixtures for the JSON schema live in `internal/render/testdata/` in the repo and are the authoritative reference for any wire-format edge cases.
 

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -40,7 +40,7 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 
 ## Success output
 
-- `list`, `show`, and `tag ls` return JSON. Render as a readable summary, or pass through. (`tag ls` returns `{"tags": [{"name": ..., "count": ...}, ...]}`; the `tags` key is always present.)
+- `list`, `show`, and `tag ls` return JSON. Render as a readable summary, or pass through. (`tag ls` returns `{"tags": [{"name": ..., "count": ...}, ...]}`; the `tags` key is always present. `show` may also include `last_researched` (RFC 3339 UTC) and `last_research_log` (absolute path) when the task has been researched; both are omitted otherwise.)
 - `add`, `update`, `append`, `close`, `reopen`, `tag add`, `tag rm` print a single line (e.g. `added 1e3900e4`). Pass through.
 
 ## `edit <frag>`

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -17,6 +17,11 @@
 // (full task body, including the canonical first line as "description")
 // and "path" (absolute, cleaned filesystem path of the task file;
 // symlinks in the configured tasks directory are preserved verbatim).
+// Two optional research fields mirror the YAML frontmatter keys defined
+// in the task package: "last_researched" (RFC 3339 timestamp in UTC) and
+// "last_research_log" (absolute path string). Both are emitted with
+// "omitempty" semantics — they are omitted entirely when the underlying
+// task has not been researched, so existing parsers continue to work.
 //
 // Human show rendering: in styled (TTY) mode, HumanShow prints a faint
 // metadata strip ({id} · {date} · {status} · [{tags}] — bracket segment
@@ -60,8 +65,10 @@ type jsonTask struct {
 
 type jsonShowTask struct {
 	jsonTask
-	Body string `json:"body"`
-	Path string `json:"path"`
+	Body            string `json:"body"`
+	Path            string `json:"path"`
+	LastResearched  string `json:"last_researched,omitempty"`
+	LastResearchLog string `json:"last_research_log,omitempty"`
 }
 
 type jsonMatch struct {
@@ -261,7 +268,12 @@ func marshalLine(v any) ([]byte, error) {
 // package documentation: the list-element fields plus the full body
 // and the absolute filesystem path of the task file.
 func JSONShow(t task.Task, path string) ([]byte, error) {
-	return marshalIndent(jsonShowTask{jsonTask: toJSONTask(t), Body: t.Body, Path: path})
+	out := jsonShowTask{jsonTask: toJSONTask(t), Body: t.Body, Path: path}
+	if !t.LastResearched.IsZero() {
+		out.LastResearched = t.LastResearched.UTC().Format(time.RFC3339)
+	}
+	out.LastResearchLog = t.LastResearchLog
+	return marshalIndent(out)
 }
 
 // JSONList renders tasks as the stable list-element schema described

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -669,3 +669,25 @@ func TestJSONShow_matchesSnapshot(t *testing.T) {
 		t.Errorf("JSON output does not match snapshot.\n--- got ---\n%s\n--- want ---\n%s", got, want)
 	}
 }
+
+func TestJSONShow_researchedMatchesSnapshot(t *testing.T) {
+	tk := task.Task{
+		ID:              "abcdef12",
+		Created:         time.Date(2026, 4, 29, 11, 30, 0, 0, time.UTC),
+		LastResearched:  time.Date(2026, 5, 1, 14, 0, 0, 0, time.UTC),
+		LastResearchLog: "/tasks/research-logs/abcdef12_2026-05-01T14-00-00.jsonl",
+		Body:            "buy milk\nremember the brand\n",
+	}
+
+	got, err := JSONShow(tk, "/tasks/open/2026-04-29T11-30_abcdef12_buy-milk.md")
+	if err != nil {
+		t.Fatalf("JSONShow: %v", err)
+	}
+	want, err := os.ReadFile("testdata/show_researched.json")
+	if err != nil {
+		t.Fatalf("read snapshot: %v", err)
+	}
+	if string(got) != string(want) {
+		t.Errorf("JSON output does not match snapshot.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}

--- a/internal/render/testdata/show_researched.json
+++ b/internal/render/testdata/show_researched.json
@@ -1,0 +1,10 @@
+{
+  "id": "abcdef12",
+  "created": "2026-04-29T11:30:00Z",
+  "description": "buy milk",
+  "tags": [],
+  "body": "buy milk\nremember the brand\n",
+  "path": "/tasks/open/2026-04-29T11-30_abcdef12_buy-milk.md",
+  "last_researched": "2026-05-01T14:00:00Z",
+  "last_research_log": "/tasks/research-logs/abcdef12_2026-05-01T14-00-00.jsonl"
+}


### PR DESCRIPTION
## Summary

- Extend `render.JSONShow` with two optional snake_case fields, `last_researched` (RFC 3339 in UTC) and `last_research_log` (absolute path), both `omitempty`. The data already lives on `task.Task` because `store.SetResearchMeta` writes it into frontmatter — purely a render-layer change.
- Update the `render` package doc comment, `docs/src/content/docs/agentic.md`, and `docs/src/content/docs/examples/worktask-slash-command.md` in the same PR per CLAUDE.md's same-PR docs/code rule.
- Add a `testdata/show_researched.json` golden fixture and `TestJSONShow_researchedMatchesSnapshot`. The existing `show.json` fixture and `TestJSONShow_matchesSnapshot` are untouched and continue to exercise the omit-when-empty contract.

## Test plan

- [x] `just ci` passes locally (fmt-check, vet, full test suite, install harness, version smoke tests).
- [x] New `TestJSONShow_researchedMatchesSnapshot` covers the populated case.
- [x] Existing `TestJSONShow_matchesSnapshot` still passes — verifies both new fields are absent on un-researched tasks.

Closes: #100

🤖 Generated with [Claude Code](https://claude.com/claude-code)