### PR TITLE
docs: lead with funnel pitch in README and docs landing

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,7 @@
 [![Docs](https://img.shields.io/badge/docs-jvcorredor.github.io%2Fworktask-blue)](https://jvcorredor.github.io/worktask/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
-A Go CLI for task management designed primarily for LLM-agent consumption (Claude Code), usable as a normal terminal CLI.
+A Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and turn them into entrypoints for agentic work in Claude Code.
 
 ## Install
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -1,11 +1,11 @@
 ---
-title: worktask
-description: A Go CLI for task management designed primarily for LLM-agent consumption (Claude Code), usable as a normal terminal CLI.
+title: Capture and investigate fast inbounds
+description: A Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and hand them off as entrypoints for agentic work in Claude Code.
 ---
 
-A Go CLI for task management designed primarily for LLM-agent consumption (Claude Code), usable as a normal terminal CLI.
+Worktask is a Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and turn them into entrypoints for agentic work in Claude Code. The funnel runs capture → soak → investigate → hand off; worktask owns capture and investigation, while shaping and handoff are left to downstream agents.
 
-Match resolution, ID generation, slug generation, and formatting all live in the CLI so the agent never has to read or rewrite task files itself. Tasks are plain markdown — `cat`, `grep`, `rg`, and `vim` work directly against the data directory without going through the binary.
+The CLI is the agent-first surface: match resolution, ID generation, slug generation, and formatting all live in the binary so the agent never has to read or rewrite task files itself. Tasks are plain markdown — `cat`, `grep`, `rg`, and `vim` work directly against the data directory without going through the binary.
 
 ## Install
 


### PR DESCRIPTION
## Summary

- Rewrite README tagline so the lead noun is the funnel use case (capture and investigate fast inbounds) instead of "task management"; "Claude Code" stays.
- Update `docs/src/content/docs/index.md` frontmatter (`title`, `description`) and body lead to match; the existing agent-first / markdown-substrate paragraph is kept as a supporting detail.
- No CLI surface, schema, or install-snippet changes. README remains a stub per `CLAUDE.md`.

Closes: #103

## Test plan

- [x] `just ci` passes locally (vet, tests, install scripts, smoke-test-version).
- [ ] Reviewer skim: tagline reads cleanly out of context (someone arriving at the README cold).
- [ ] Reviewer skim: docs landing H1 (now "Capture and investigate fast inbounds") reads OK in the Starlight nav.

🤖 Generated with [Claude Code](https://claude.com/claude-code)