### PR TITLE
docs(adr): reframe ADR-0001 around soak-phase triage

### DIFF
--- a/docs/adr/0001-tag-model.md
+++ b/docs/adr/0001-tag-model.md
@@ -6,7 +6,13 @@ Accepted
 
 ## Context
 
-Tasks need lightweight categorisation that survives the file-based storage format and is accessible to both human users and programmatic consumers (agents, scripts). The design must fit the existing frontmatter codec without breaking backward compatibility.
+Worktask captures fast inbounds and shepherds them through a soak phase before investigation fires. During soak the user accumulates context on a captured task — `append`, `update`, and `edit` mutate the body — but those primitives don't answer *what kind of inbound this is*. A bug report soaks differently from a leadership question; an "incident postmortem" capture wants different downstream handling from a "Q3 roadmap decision" capture. Without a triage primitive, the soak-phase backlog is an undifferentiated stream and the user has to re-read each task to remember its shape.
+
+Tags are the soak-phase triage label that fills that gap. The user attaches a short, lowercase identifier at capture time — `bug`, `urgent`, `roadmap`, `incident` — to mark intent without committing to a folder layout, a status enum, or a separate metadata store. The label travels with the task in its frontmatter, so it survives the file-based storage format and stays accessible to both human users and programmatic consumers (agents, scripts).
+
+A secondary use case follows from the same primitive: once a cohort of tasks carries the same label, batch-routing for sweeps is cheap. `worktask research --tag <tag>` fires investigation across the cohort in one pass; `worktask list --tag <tag>` produces a soak-phase backlog view scoped to one kind of inbound. These flows reuse the triage label rather than reintroducing a categorisation system.
+
+The design must fit the existing frontmatter codec without breaking backward compatibility.
 
 ## Decision
 


### PR DESCRIPTION
## Summary

- Reframe `docs/adr/0001-tag-model.md` Context around soak-phase triage: tags answer "what kind of inbound is this?" while `append`/`update`/`edit` handle body mutation during soak.
- Call out batch-routing for sweeps (`research --tag`, `list --tag`) as the secondary use case that reuses the same triage label.
- Decision sub-sections (Tag format, On-disk format, Store interface, CLI, JSON output) and Consequences are unchanged — the data model is unchanged.

Closes: #104
Parent: #99

## Test plan

- [x] `just ci` passes locally
- [ ] Manual review confirms Context leads with soak-phase triage and batch-routing appears as secondary
- [ ] Manual review confirms Decision sub-sections still match the implemented model verbatim
- [ ] Manual review confirms Status remains `Accepted`

🤖 Generated with [Claude Code](https://claude.com/claude-code)