### PR TITLE
feat(research): delegate cmd/research.go to research.Coordinator

### DIFF
--- a/cmd/research.go
+++ b/cmd/research.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"os"
 	"os/signal"
-	"path/filepath"
 	"syscall"
 	"time"
 
@@ -14,11 +13,8 @@ import (
 
 	"github.com/jvcorredor/worktask/internal/config"
 	"github.com/jvcorredor/worktask/internal/render"
-	researchlog "github.com/jvcorredor/worktask/internal/research/log"
-	"github.com/jvcorredor/worktask/internal/research/pool"
+	"github.com/jvcorredor/worktask/internal/research"
 	"github.com/jvcorredor/worktask/internal/research/prompt"
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/research/writeback"
 	"github.com/jvcorredor/worktask/internal/store"
 )
 
@@ -35,6 +31,12 @@ const (
 	defaultResearchConcurrency = 3
 	defaultResearchTimeout     = 10 * time.Minute
 )
+
+// researchRunFunc is the seam the cmd shell hands to research.New. The
+// production wiring runs the headless claude binary via the runner
+// subpackage; tests substitute an in-memory stub to avoid invoking
+// claude.
+var researchRunFunc research.RunFunc = research.DefaultRun
 
 var researchCmd = &cobra.Command{
 	Use:   "research [<fragment>]",
@@ -55,10 +57,25 @@ var researchCmd = &cobra.Command{
 		}
 		s := store.New(cfg.TasksDir)
 
-		if len(args) == 1 {
-			return runSingleResearch(cmd, cfg, s, args[0])
+		tmpl, err := prompt.Load(cfg.ResearchPromptPath)
+		if err != nil {
+			return err
 		}
-		return runBatchResearch(cmd, cfg, s, normalizedTag)
+
+		coord, err := research.New(s, researchRunFunc, research.Config{
+			TasksDir:       cfg.TasksDir,
+			WorkingLogPath: cfg.WorkingLogPath,
+			Model:          resolveResearchModel(cfg),
+			ExtraTools:     cfg.ResearchExtraTools,
+		}, tmpl)
+		if err != nil {
+			return err
+		}
+
+		if len(args) == 1 {
+			return runSingleResearch(cmd, s, coord, args[0])
+		}
+		return runBatchResearch(cmd, s, coord, normalizedTag)
 	},
 }
 
@@ -72,83 +89,41 @@ func init() {
 	rootCmd.AddCommand(researchCmd)
 }
 
-func runSingleResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, fragment string) error {
+func runSingleResearch(cmd *cobra.Command, s *store.Store, coord *research.Coordinator, fragment string) error {
 	t, _, _, err := s.Get(fragment)
 	if err != nil {
 		return handleResolveError(cmd, s, fragment, err)
 	}
 
-	tmpl, err := prompt.Load(cfg.ResearchPromptPath)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	out, err := coord.RunOne(ctx, t)
 	if err != nil {
 		return err
 	}
-	rendered, err := prompt.Render(tmpl, t)
-	if err != nil {
-		return err
-	}
 
-	runStart := time.Now().UTC()
-	logPath := researchlog.Path(cfg.TasksDir, t.ID, runStart)
-	logPathRel, err := filepath.Rel(cfg.TasksDir, logPath)
-	if err != nil {
-		logPathRel = logPath
-	}
-
-	result, runErr := runner.Run(context.Background(), runner.RunInput{
-		Prompt:     rendered,
-		LogPath:    logPath,
-		Model:      resolveResearchModel(cfg),
-		ExtraTools: cfg.ResearchExtraTools,
-	}, runner.OSExec{})
-	if runErr != nil {
-		result = runner.Result{
-			Status:  "failed",
-			Summary: runErr.Error(),
-		}
-	}
-
-	if err := writeback.Apply(s, writeback.Input{
-		Fragment:       t.ID,
-		Result:         result,
-		RunStart:       runStart,
-		LogPath:        logPath,
-		LogPathRel:     logPathRel,
-		WorkingLogPath: cfg.WorkingLogPath,
-	}); err != nil {
-		return err
-	}
-
-	summary, err := render.JSONResearchRun(render.ResearchRun{
-		ID:          t.ID,
-		Description: firstLineOfBody(t.Body),
-		Status:      result.Status,
-		Summary:     result.Summary,
-		LogPath:     logPathRel,
-		Error:       errString(runErr),
+	line, err := render.JSONResearchRun(render.ResearchRun{
+		ID:          out.ID,
+		Description: out.Description,
+		Status:      out.Status,
+		Summary:     out.Summary,
+		LogPath:     out.LogPath,
+		Error:       out.Error,
 	})
 	if err != nil {
 		return err
 	}
-	if _, err := cmd.OutOrStdout().Write(summary); err != nil {
+	if _, err := cmd.OutOrStdout().Write(line); err != nil {
 		return err
 	}
-	if result.Status == "failed" {
+	if out.Status == "failed" {
 		return errExit
 	}
 	return nil
 }
 
-// itemMeta keeps the per-task absolute log path next to the queue. The pool
-// only echoes back the relative path it was given (via Item.LogPath) for
-// output, so the absolute path must be looked up in cmd/ for runner +
-// writeback callbacks.
-type itemMeta struct {
-	logPath    string
-	logPathRel string
-	runStart   time.Time
-}
-
-func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, tagFilter string) error {
+func runBatchResearch(cmd *cobra.Command, s *store.Store, coord *research.Coordinator, tagFilter string) error {
 	openTasks, err := s.List(store.FilterOpen, 0, tagFilter)
 	if err != nil {
 		return err
@@ -160,67 +135,22 @@ func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, tag
 		stale: researchStale,
 	}, now)
 
-	tmpl, err := prompt.Load(cfg.ResearchPromptPath)
+	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
+	defer cancel()
+
+	events, done, err := coord.RunBatch(ctx, toResearch, len(skipped), research.BatchOpts{
+		Concurrency: researchConcurrency,
+		Timeout:     researchTimeout,
+	})
 	if err != nil {
 		return err
 	}
 
-	items := make([]pool.Item, 0, len(toResearch))
-	meta := make(map[string]itemMeta, len(toResearch))
-	for _, t := range toResearch {
-		rendered, err := prompt.Render(tmpl, t)
-		if err != nil {
-			return err
-		}
-		runStart := time.Now().UTC()
-		logPath := researchlog.Path(cfg.TasksDir, t.ID, runStart)
-		logPathRel, err := filepath.Rel(cfg.TasksDir, logPath)
-		if err != nil {
-			logPathRel = logPath
-		}
-		items = append(items, pool.Item{
-			Task:    t,
-			Prompt:  rendered,
-			LogPath: logPathRel,
-		})
-		meta[t.ID] = itemMeta{logPath: logPath, logPathRel: logPathRel, runStart: runStart}
-	}
-
-	ctx, cancel := signal.NotifyContext(context.Background(), os.Interrupt, syscall.SIGTERM)
-	defer cancel()
-
-	model := resolveResearchModel(cfg)
-	extraTools := cfg.ResearchExtraTools
-	runFn := func(ctx context.Context, item pool.Item) (runner.Result, error) {
-		return runner.Run(ctx, runner.RunInput{
-			Prompt:     item.Prompt,
-			LogPath:    meta[item.Task.ID].logPath,
-			Model:      model,
-			ExtraTools: extraTools,
-		}, runner.OSExec{})
-	}
-
-	res := pool.Run(ctx, items, runFn, pool.Opts{
-		Concurrency: researchConcurrency,
-		Timeout:     researchTimeout,
-	})
-
 	stdout := cmd.OutOrStdout()
-	for ev := range res.Events {
+	for ev := range events {
 		emitProgressEvent(stdout, ev)
-		if ev.Type == "task_done" {
-			m := meta[ev.Task.ID]
-			_ = writeback.Apply(s, writeback.Input{
-				Fragment:       ev.Task.ID,
-				Result:         ev.Result,
-				RunStart:       m.runStart,
-				LogPath:        m.logPath,
-				LogPathRel:     m.logPathRel,
-				WorkingLogPath: cfg.WorkingLogPath,
-			})
-		}
 	}
-	summary := <-res.Done
+	summary := <-done
 
 	final := render.ResearchSummary{
 		BatchID:  summary.BatchID,
@@ -230,7 +160,7 @@ func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, tag
 			Findings: summary.Totals.Findings,
 			Clarify:  summary.Totals.Clarify,
 			Failed:   summary.Totals.Failed,
-			Skipped:  len(skipped),
+			Skipped:  summary.Totals.Skipped,
 		},
 	}
 	for _, r := range summary.Results {
@@ -252,32 +182,21 @@ func runBatchResearch(cmd *cobra.Command, cfg config.Config, s *store.Store, tag
 	return err
 }
 
-func emitProgressEvent(stdout io.Writer, ev pool.Event) {
-	re := render.ResearchEvent{Type: ev.Type, ID: ev.Task.ID}
-	switch ev.Type {
-	case "task_started":
-		re.Description = firstLineOfBody(ev.Task.Body)
-		re.Started = ev.Started
-	case "task_done":
-		re.Status = ev.Result.Status
-		re.Summary = ev.Result.Summary
-	case "task_failed":
-		re.Error = errString(ev.Err)
+func emitProgressEvent(stdout io.Writer, ev research.Event) {
+	re := render.ResearchEvent{
+		Type:        ev.Type,
+		ID:          ev.ID,
+		Description: ev.Description,
+		Started:     ev.Started,
+		Status:      ev.Status,
+		Summary:     ev.Summary,
+		Error:       errString(ev.Err),
 	}
 	line, err := render.JSONResearchEvent(re)
 	if err != nil {
 		return
 	}
 	_, _ = stdout.Write(line)
-}
-
-func firstLineOfBody(body string) string {
-	for i := 0; i < len(body); i++ {
-		if body[i] == '\n' {
-			return body[:i]
-		}
-	}
-	return body
 }
 
 func errString(err error) string {

--- a/cmd/research_test.go
+++ b/cmd/research_test.go
@@ -1,0 +1,175 @@
+package cmd
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/jvcorredor/worktask/internal/research/runner"
+	"github.com/jvcorredor/worktask/internal/task"
+)
+
+// TestResearchCmd_batchForwardsCoordinatorOutputsIntoRender verifies the
+// cmd shell stitches research.Coordinator outputs into the existing
+// render.JSONResearchEvent / render.JSONResearchSummary functions
+// correctly: per-task task_started/task_done/task_failed lines arrive on
+// stdout, and the final summary line carries the right totals and
+// per-task results. The real claude binary is never invoked — the test
+// injects a stub research.RunFunc via the cmd-level seam.
+func TestResearchCmd_batchForwardsCoordinatorOutputsIntoRender(t *testing.T) {
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	if err := os.MkdirAll(openDir, 0o755); err != nil {
+		t.Fatalf("mkdir open: %v", err)
+	}
+	writeOpenTask(t, openDir, "aaaaaaaa", "alpha buy milk")
+	writeOpenTask(t, openDir, "bbbbbbbb", "beta debug login")
+
+	prevRun := researchRunFunc
+	t.Cleanup(func() { researchRunFunc = prevRun })
+	researchRunFunc = func(_ context.Context, in runner.RunInput) (runner.Result, error) {
+		switch {
+		case strings.Contains(in.Prompt, "alpha"):
+			return runner.Result{
+				Status:  "findings",
+				Summary: "alpha summary",
+				Body:    "alpha body",
+				Tokens:  42,
+			}, nil
+		case strings.Contains(in.Prompt, "beta"):
+			return runner.Result{}, errors.New("beta blew up")
+		}
+		t.Fatalf("unexpected prompt: %q", in.Prompt)
+		return runner.Result{}, nil
+	}
+
+	prevConcurrency, prevAll := researchConcurrency, researchAll
+	t.Cleanup(func() {
+		researchConcurrency = prevConcurrency
+		researchAll = prevAll
+	})
+
+	var stdout, stderr bytes.Buffer
+	rootCmd.SetOut(&stdout)
+	rootCmd.SetErr(&stderr)
+	rootCmd.SetArgs([]string{"research", "--all", "--concurrency=1"})
+	t.Cleanup(func() {
+		rootCmd.SetOut(nil)
+		rootCmd.SetErr(nil)
+		rootCmd.SetArgs(nil)
+	})
+
+	if err := rootCmd.Execute(); err != nil {
+		t.Fatalf("execute research: %v (stderr=%s)", err, stderr.String())
+	}
+
+	out := stdout.String()
+	if out == "" {
+		t.Fatalf("research --all produced no stdout")
+	}
+
+	// Each event is a single newline-terminated JSON object; the final
+	// summary is a multi-line indented JSON object. json.Decoder handles
+	// both shapes via successive Decode calls.
+	dec := json.NewDecoder(strings.NewReader(out))
+	var docs []map[string]any
+	for {
+		var m map[string]any
+		err := dec.Decode(&m)
+		if errors.Is(err, io.EOF) {
+			break
+		}
+		if err != nil {
+			t.Fatalf("decode JSON doc: %v\nremaining=%q", err, out)
+		}
+		docs = append(docs, m)
+	}
+	if len(docs) < 2 {
+		t.Fatalf("expected at least one event + summary; got %d docs:\n%s", len(docs), out)
+	}
+
+	summary := docs[len(docs)-1]
+	events := docs[:len(docs)-1]
+
+	got := map[string]map[string]map[string]any{} // id -> event-type -> doc
+	for _, ev := range events {
+		evType, _ := ev["event"].(string)
+		id, _ := ev["id"].(string)
+		if got[id] == nil {
+			got[id] = map[string]map[string]any{}
+		}
+		got[id][evType] = ev
+	}
+
+	if _, ok := got["aaaaaaaa"]["task_started"]; !ok {
+		t.Errorf("missing task_started for alpha (got=%v)", events)
+	}
+	if done, ok := got["aaaaaaaa"]["task_done"]; !ok {
+		t.Errorf("missing task_done for alpha (got=%v)", events)
+	} else {
+		if done["status"] != "findings" {
+			t.Errorf("alpha task_done.status = %v; want findings", done["status"])
+		}
+		if done["summary"] != "alpha summary" {
+			t.Errorf("alpha task_done.summary = %v; want alpha summary", done["summary"])
+		}
+	}
+
+	if _, ok := got["bbbbbbbb"]["task_started"]; !ok {
+		t.Errorf("missing task_started for beta (got=%v)", events)
+	}
+	if failed, ok := got["bbbbbbbb"]["task_failed"]; !ok {
+		t.Errorf("missing task_failed for beta (got=%v)", events)
+	} else if errStr, _ := failed["error"].(string); !strings.Contains(errStr, "beta blew up") {
+		t.Errorf("beta task_failed.error = %q; want it to contain runner error", errStr)
+	}
+
+	totals, _ := summary["totals"].(map[string]any)
+	if got, want := numField(totals, "findings"), 1.0; got != want {
+		t.Errorf("totals.findings = %v; want %v", got, want)
+	}
+	if got, want := numField(totals, "failed"), 1.0; got != want {
+		t.Errorf("totals.failed = %v; want %v", got, want)
+	}
+	if results, _ := summary["results"].([]any); len(results) != 2 {
+		t.Errorf("len(summary.results) = %d; want 2", len(results))
+	}
+}
+
+func writeOpenTask(t *testing.T, openDir, id, body string) {
+	t.Helper()
+	tk := task.Task{
+		ID:      id,
+		Created: time.Date(2026, 4, 1, 9, 0, 0, 0, time.UTC),
+		Body:    body + "\n",
+	}
+	raw, err := task.Encode(tk)
+	if err != nil {
+		t.Fatalf("task.Encode: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(openDir, id+".md"), raw, 0o644); err != nil {
+		t.Fatalf("write task file: %v", err)
+	}
+}
+
+func numField(m map[string]any, k string) float64 {
+	if m == nil {
+		return -1
+	}
+	v, ok := m[k]
+	if !ok {
+		return -1
+	}
+	f, _ := v.(float64)
+	return f
+}

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -200,6 +200,15 @@ Flags:
 
 The shipped binary's `--allowed-tools` baseline contains five built-in read-only tools and nothing else: `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`. To extend the allowlist with MCP tools or pattern-restricted `Bash(...)` invocations on a per-machine basis, add a [`research_extra_tools`](./config.md#research_extra_tools) block to your `config.toml`. There is no `--extra-tool` flag; tool availability is a per-machine property, not a per-invocation one.
 
+### Batch outcome reporting
+
+In a batch run (`worktask research` or `worktask research --all`), every task makes it into the final summary, even when prep- or post-run plumbing fails. Two cases that previously fell through the cracks now surface as `failed` outcomes:
+
+- **Writeback errors** (the agent succeeded but the cmd could not append the Research section, set the `last_researched` frontmatter, or append the worklog line — for example, the task file went missing mid-run, or the worklog directory is unwritable) emit a `task_failed` event and a `failed` row in the summary. The agent's original summary text is preserved in the row's `summary` field; the writeback error message goes into `error`. Previously these were silently reported as if the writeback had succeeded.
+- **Per-task `prompt.Render` failures during prep** (a malformed override template, or a task whose frontmatter does not satisfy a custom template's field references) emit a synthetic `task_failed` event for that task and a `failed` row in the summary. Other tasks in the batch still run. Previously a single render failure aborted the whole sweep before any task ran.
+
+Both cases count toward `totals.failed` in the summary; the summary's `totals.skipped` continues to count only the staleness-based skip path.
+
 JSON output is documented in [Agentic usage](./agentic.md).
 
 ## `version`

--- a/internal/research/research.go
+++ b/internal/research/research.go
@@ -35,6 +35,15 @@ import (
 // filesystem.
 type RunFunc func(ctx context.Context, in runner.RunInput) (runner.Result, error)
 
+// DefaultRun is the production [RunFunc]: it spawns the headless claude
+// binary via [runner.OSExec]. The cmd shell hands this to [New] in
+// production wiring; tests pass an in-memory stub instead so the test
+// path never touches claude. Exposing it from this package lets cmd
+// drop its direct dependency on the [runner] subpackage.
+func DefaultRun(ctx context.Context, in runner.RunInput) (runner.Result, error) {
+	return runner.Run(ctx, in, runner.OSExec{})
+}
+
 // Config carries the fully-resolved settings the [Coordinator] needs.
 // All values are pre-resolved at the cmd boundary — Model and
 // ExtraTools have already absorbed flag overrides, and the prompt


### PR DESCRIPTION
## Summary

- Replace `cmd/research.go`'s hand-stitched orchestration with a thin shell that constructs and drives a `research.Coordinator`. The cmd shell keeps the input-boundary responsibilities (flag parsing, config load, fragment resolve, prompt template load, signal handling, JSON render loop, `errExit` on failed status) and delegates everything else.
- Two intentional behavior changes that follow from delegating to the Coordinator:
  - **Writeback failures in batch mode** now surface as `failed` outcomes. The agent's original summary is preserved in `summary`; the writeback error lands in `error`. Previously these were silently reported as if the writeback had succeeded.
  - **Per-task `prompt.Render` failures during batch prep** emit a synthetic `task_failed` event and a `failed` row in the summary; other tasks in the batch still run. Previously a single render failure aborted the whole sweep before any task ran.
- `cmd` no longer imports `internal/research/{log,pool,runner,writeback}`. Only `internal/research` and `internal/research/prompt` remain. Production wiring lives behind a new `research.DefaultRun` helper so cmd does not have to reach into the `runner` subpackage; tests substitute a stub `research.RunFunc` via the `researchRunFunc` package-level seam.
- The `itemMeta` sidecar map is deleted — its replacement is the private `preparedItem` map inside `Coordinator.RunBatch`.
- Same-PR docs update: `docs/src/content/docs/cli.md` `research` section gains a "Batch outcome reporting" subsection flagging both behavior changes in user-visible terms. The JSON output schema is unchanged, so the slash-command file does not need an update.

## Test plan

- [x] `go test ./...` passes
- [x] `just ci` passes (fmt-check, vet, test, install tests)
- [x] `golangci-lint run ./...` passes (0 issues)
- [x] New `TestResearchCmd_batchForwardsCoordinatorOutputsIntoRender` exercises the cmd shell end-to-end via cobra with an injected stub `research.RunFunc`, asserting `task_started` / `task_done` / `task_failed` event lines and the final summary's totals and results array. The real claude binary is never invoked.
- [ ] **Manual verification required before merge** (no e2e test exists today; this PR does not add one): run `worktask research --all` against a tasks directory containing several open tasks and confirm streaming events plus final summary land as expected, including at least one task that exercises the writeback-failure or render-failure path.

Closes: #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)