### PR TITLE
feat(render): include tags in ambiguous-error matches

### DIFF
--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -33,7 +33,7 @@ Golden fixtures for the JSON schema live in `internal/render/testdata/` in the r
 When a `<fragment>` resolves ambiguously or not at all, the command exits non-zero. In `--format=json`, both cases produce a stable JSON envelope with an `error` discriminator so agents can branch without parsing prose.
 
 ```json
-{ "error": "ambiguous", "fragment": "milk", "matches": [{ "id": "...", "description": "..." }] }
+{ "error": "ambiguous", "fragment": "milk", "matches": [{ "id": "...", "description": "...", "tags": [] }] }
 ```
 
 ```json

--- a/docs/src/content/docs/examples/worktask-slash-command.md
+++ b/docs/src/content/docs/examples/worktask-slash-command.md
@@ -34,7 +34,7 @@ If the subcommand is missing or unrecognized, print the table and stop. Do not g
 
 When the CLI exits non-zero, parse stdout as JSON and branch on the `error` field:
 
-- `"error": "ambiguous"` — fragment matched multiple tasks. Show `matches` (each `{id, description}`) and ask the user which one. Do NOT pick. Do NOT retry with a longer fragment.
+- `"error": "ambiguous"` — fragment matched multiple tasks. Show `matches` (each `{id, description, tags}`; `tags` is always present, empty array when none) and ask the user which one. Do NOT pick. Do NOT retry with a longer fragment.
 - `"error": "no_match"` — fragment matched nothing. Show `open_tasks` so the user can pick. Do NOT invent IDs or fabricate matches.
 - Any other non-zero exit: surface stderr verbatim.
 

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -72,8 +72,9 @@ type jsonShowTask struct {
 }
 
 type jsonMatch struct {
-	ID          string `json:"id"`
-	Description string `json:"description"`
+	ID          string   `json:"id"`
+	Description string   `json:"description"`
+	Tags        []string `json:"tags"`
 }
 
 type jsonErrAmbiguous struct {
@@ -101,11 +102,18 @@ func JSONErrorNoMatch(fragment string, openTasks []task.Task) ([]byte, error) {
 
 // JSONErrorAmbiguous renders the ambiguous-fragment error envelope: an
 // object with error="ambiguous", the offending fragment, and the
-// candidate tasks the fragment matched.
+// candidate tasks the fragment matched. Each match carries id,
+// description, and tags; tags is always present and serializes as []
+// when the candidate has none, so callers can jq '.matches[].tags'
+// without null-checking.
 func JSONErrorAmbiguous(fragment string, candidates []store.Candidate) ([]byte, error) {
 	matches := make([]jsonMatch, 0, len(candidates))
 	for _, c := range candidates {
-		matches = append(matches, jsonMatch{ID: c.ID, Description: c.Description})
+		tags := c.Tags
+		if tags == nil {
+			tags = []string{}
+		}
+		matches = append(matches, jsonMatch{ID: c.ID, Description: c.Description, Tags: tags})
 	}
 	return marshalIndent(jsonErrAmbiguous{Error: "ambiguous", Fragment: fragment, Matches: matches})
 }

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -2,7 +2,9 @@ package render
 
 import (
 	"bytes"
+	"encoding/json"
 	"os"
+	"reflect"
 	"strings"
 	"testing"
 	"time"
@@ -42,7 +44,7 @@ func TestJSONList_matchesSnapshot(t *testing.T) {
 
 func TestJSONErrorAmbiguous_matchesSnapshot(t *testing.T) {
 	candidates := []store.Candidate{
-		{ID: "11111111", Description: "buy milk"},
+		{ID: "11111111", Description: "buy milk", Tags: []string{"errand", "shopping"}},
 		{ID: "22222222", Description: "buy milkshake"},
 	}
 	got, err := JSONErrorAmbiguous("milk", candidates)
@@ -55,6 +57,40 @@ func TestJSONErrorAmbiguous_matchesSnapshot(t *testing.T) {
 	}
 	if string(got) != string(want) {
 		t.Errorf("JSON output does not match snapshot.\n--- got ---\n%s\n--- want ---\n%s", got, want)
+	}
+}
+
+func TestJSONErrorAmbiguous_eachMatchCarriesTags(t *testing.T) {
+	candidates := []store.Candidate{
+		{ID: "11111111", Description: "buy milk", Tags: []string{"errand", "shopping"}},
+		{ID: "22222222", Description: "buy milkshake"},
+	}
+	got, err := JSONErrorAmbiguous("milk", candidates)
+	if err != nil {
+		t.Fatalf("JSONErrorAmbiguous: %v", err)
+	}
+	var parsed struct {
+		Matches []struct {
+			ID   string    `json:"id"`
+			Tags *[]string `json:"tags"`
+		} `json:"matches"`
+	}
+	if err := json.Unmarshal(got, &parsed); err != nil {
+		t.Fatalf("unmarshal: %v\noutput: %s", err, got)
+	}
+	if len(parsed.Matches) != 2 {
+		t.Fatalf("len(matches) = %d; want 2", len(parsed.Matches))
+	}
+	for i, m := range parsed.Matches {
+		if m.Tags == nil {
+			t.Errorf("matches[%d] (id=%s): tags key missing or null; want array (empty when no tags)", i, m.ID)
+		}
+	}
+	if got, want := parsed.Matches[0].Tags, []string{"errand", "shopping"}; got == nil || !reflect.DeepEqual(*got, want) {
+		t.Errorf("matches[0].tags = %v; want %v", got, want)
+	}
+	if got := parsed.Matches[1].Tags; got == nil || len(*got) != 0 {
+		t.Errorf("matches[1].tags = %v; want empty array (nil tags must serialize as [])", got)
 	}
 }
 

--- a/internal/render/testdata/error_ambiguous.json
+++ b/internal/render/testdata/error_ambiguous.json
@@ -4,11 +4,16 @@
   "matches": [
     {
       "id": "11111111",
-      "description": "buy milk"
+      "description": "buy milk",
+      "tags": [
+        "errand",
+        "shopping"
+      ]
     },
     {
       "id": "22222222",
-      "description": "buy milkshake"
+      "description": "buy milkshake",
+      "tags": []
     }
   ]
 }

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -249,10 +249,12 @@ type loaded struct {
 }
 
 // Candidate is a one-line summary of a task surfaced when fragment
-// resolution is ambiguous.
+// resolution is ambiguous. Tags carries the resolved task's tags so
+// callers can disambiguate by topic; it is nil when the task has none.
 type Candidate struct {
 	ID          string
 	Description string
+	Tags        []string
 }
 
 // ErrAmbiguous is returned when a fragment resolves to more than one
@@ -529,7 +531,7 @@ func (s *Store) resolve(fragment string, subdirs []string) (loaded, error) {
 		if len(hits) > 1 {
 			cands := make([]Candidate, 0, len(hits))
 			for _, h := range hits {
-				cands = append(cands, Candidate{ID: h.task.ID, Description: firstLine(h.task.Body)})
+				cands = append(cands, Candidate{ID: h.task.ID, Description: firstLine(h.task.Body), Tags: h.task.Tags})
 			}
 			return loaded{}, &ErrAmbiguous{Fragment: fragment, Candidates: cands}
 		}

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"testing"
 	"time"
 
@@ -238,6 +239,38 @@ func TestGet_ambiguousReturnsTypedErrorWithCandidates(t *testing.T) {
 	}
 	if gotIDs["22222222"] != "buy milkshake" {
 		t.Errorf("Candidates[22222222].Description = %q; want %q", gotIDs["22222222"], "buy milkshake")
+	}
+}
+
+func TestGet_ambiguousCandidatesCarryTags(t *testing.T) {
+	dir := t.TempDir()
+	s := New(dir)
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "11111111" }
+	if _, err := s.Add("buy milk", "errand", "shopping"); err != nil {
+		t.Fatalf("Add A: %v", err)
+	}
+	s.Now = func() time.Time { return time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC) }
+	s.NewID = func() string { return "22222222" }
+	if _, err := s.Add("buy milkshake"); err != nil {
+		t.Fatalf("Add B: %v", err)
+	}
+
+	_, _, _, err := s.Get("milk")
+	var amb *ErrAmbiguous
+	if !errors.As(err, &amb) {
+		t.Fatalf("error type = %T (%v); want *ErrAmbiguous", err, err)
+	}
+	gotTags := map[string][]string{}
+	for _, c := range amb.Candidates {
+		gotTags[c.ID] = c.Tags
+	}
+	wantTagged := []string{"errand", "shopping"}
+	if !reflect.DeepEqual(gotTags["11111111"], wantTagged) {
+		t.Errorf("Candidates[11111111].Tags = %v; want %v", gotTags["11111111"], wantTagged)
+	}
+	if got := gotTags["22222222"]; len(got) != 0 {
+		t.Errorf("Candidates[22222222].Tags = %v; want empty (no tags on source task)", got)
 	}
 }
 


### PR DESCRIPTION
## Summary
- `store.Candidate` gains `Tags []string`, populated by the fragment resolver from the resolved task.
- `render.jsonMatch` gains `Tags []string` (no `omitempty`); nil tags serialize as `[]` so agents can `jq '.matches[].tags'` without null-checking.
- Snapshot test + `error_ambiguous.json` golden updated to exercise both tagged and untagged candidates. `error_no_match.json` already carried tags via the shared list-element schema and needs no update.
- Docs: `docs/src/content/docs/agentic.md` and `docs/src/content/docs/examples/worktask-slash-command.md` reflect the additive `tags` field on each match.

Built TDD-style with two vertical slices (render layer, then resolver), each red→green.

Closes: #81

## Test plan
- [x] `just ci` (vet + tests + install harness + smoke version)
- [x] `golangci-lint run ./...` (0 issues)
- [x] New behavioral test `TestJSONErrorAmbiguous_eachMatchCarriesTags` covers nil-tags-serialize-as-`[]`
- [x] New integration test `TestGet_ambiguousCandidatesCarryTags` covers resolver populating `Candidate.Tags`
- [x] Existing `TestJSONErrorAmbiguous_matchesSnapshot` extended to mix tagged and untagged candidates

🤖 Generated with [Claude Code](https://claude.com/claude-code)