### PR TITLE
refactor!: rename worktask → btw / bytheway

### DIFF
--- a/.github/scripts/smoke-test-version.sh
+++ b/.github/scripts/smoke-test-version.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-# Asserts that the `worktask` binary on PATH reports the version named
+# Asserts that the `btw` binary on PATH reports the version named
 # in EXPECTED_VERSION. Used by the post-release smoke-test job in
 # .github/workflows/release.yml: a mismatch fails the workflow loudly so
 # the maintainer is alerted within minutes of a broken release.
@@ -13,13 +13,13 @@ die() {
 
 [ -n "${EXPECTED_VERSION:-}" ] || die 'EXPECTED_VERSION is unset'
 
-command -v worktask >/dev/null 2>&1 \
-    || die 'worktask not found on PATH'
+command -v btw >/dev/null 2>&1 \
+    || die 'btw not found on PATH'
 
-actual=$(worktask version --format=json | jq -r '.version') \
-    || die 'failed to read version from worktask version --format=json'
+actual=$(btw version --format=json | jq -r '.version') \
+    || die 'failed to read version from btw version --format=json'
 
 [ "$actual" = "$EXPECTED_VERSION" ] \
-    || die "worktask version mismatch: expected $EXPECTED_VERSION, got $actual"
+    || die "btw version mismatch: expected $EXPECTED_VERSION, got $actual"
 
-printf 'smoke test passed: worktask version reports %s\n' "$actual"
+printf 'smoke test passed: btw version reports %s\n' "$actual"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -67,9 +67,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v6
 
-      - name: Install worktask via published install script
+      - name: Install btw via published install script
         run: |
-          curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+          curl -fsSL https://jvcorredor.github.io/btw/install.sh | sh
           printf '%s/.local/bin\n' "$HOME" >>"$GITHUB_PATH"
 
       - name: Assert installed binary reports the released version

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,11 +1,11 @@
 version: 2
 
-project_name: worktask
+project_name: btw
 
 builds:
-  - id: worktask
+  - id: btw
     main: .
-    binary: worktask
+    binary: btw
     env:
       - CGO_ENABLED=0
     goos:
@@ -18,19 +18,19 @@ builds:
       - -trimpath
     ldflags:
       - -s -w
-      - -X github.com/jvcorredor/worktask/internal/version.Version={{ .Version }}
-      - -X github.com/jvcorredor/worktask/internal/version.Commit={{ .FullCommit }}
-      - -X github.com/jvcorredor/worktask/internal/version.Date={{ .Date }}
+      - -X github.com/jvcorredor/bytheway/internal/version.Version={{ .Version }}
+      - -X github.com/jvcorredor/bytheway/internal/version.Commit={{ .FullCommit }}
+      - -X github.com/jvcorredor/bytheway/internal/version.Date={{ .Date }}
 
 archives:
   # `format:` (singular) and the absence of `ids:` are required for
   # compatibility with the goreleaser library version pinned by
   # hooks-goreleaser (currently goreleaser v2.3.2). The newer
-  # `formats: [tar.gz]` and `ids: [worktask]` schema fields are
+  # `formats: [tar.gz]` and `ids: [btw]` schema fields are
   # rejected by that version's unmarshaller.
-  - id: worktask
+  - id: btw
     format: tar.gz
-    name_template: worktask_{{ .Version }}_{{ .Os }}_{{ .Arch }}
+    name_template: bytheway_{{ .Version }}_{{ .Os }}_{{ .Arch }}
     files:
       - LICENSE
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -2,13 +2,13 @@
 
 ## Documentation
 
-The docs site at <https://jvcorredor.github.io/worktask/> is the canonical source for everything user-visible about `worktask` — subcommands, flags, JSON schema, file format, config keys, and the agentic-usage patterns. The site source lives in `docs/` and is published via `.github/workflows/docs.yml` on every push to `main` that touches `docs/**`.
+The docs site at <https://jvcorredor.github.io/bytheway/> is the canonical source for everything user-visible about `btw` — subcommands, flags, JSON schema, file format, config keys, and the agentic-usage patterns. The site source lives in `docs/` and is published via `.github/workflows/docs.yml` on every push to `main` that touches `docs/**`.
 
 `README.md` is a stub: tagline, install command, and a link to the docs site. Do not grow it back into a long-form reference. Anything user-visible belongs on the docs site.
 
 Any PR that changes user-visible CLI surface — subcommands, flags, JSON schema, file format, or config keys — must update the corresponding docs page in the same PR. Same-PR is the rule because it is the only thing keeping the docs site from drifting out of sync with the CLI; there is no auto-generated content and no link-checking in CI.
 
-The vendored reference slash command at `docs/src/content/docs/examples/worktask-slash-command.md` is part of that contract. If a JSON schema or error-envelope change requires updating how an agent wraps the CLI, the slash-command file is updated in the same PR as the schema change.
+The vendored reference slash command at `docs/src/content/docs/examples/btw-slash-command.md` is part of that contract. If a JSON schema or error-envelope change requires updating how an agent wraps the CLI, the slash-command file is updated in the same PR as the schema change.
 
 ## Local commands
 
@@ -30,7 +30,7 @@ Exported Go symbols carry doc comments in the standard Go convention: a complete
 
 ### Issue tracker
 
-GitHub Issues at `jvcorredor/worktask`, accessed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
+GitHub Issues at `jvcorredor/bytheway`, accessed via the `gh` CLI. See `docs/agents/issue-tracker.md`.
 
 ### Triage labels
 

--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-# worktask
+# bytheway
 
-[![Go Reference](https://pkg.go.dev/badge/github.com/jvcorredor/worktask.svg)](https://pkg.go.dev/github.com/jvcorredor/worktask)
-[![Go Report Card](https://goreportcard.com/badge/github.com/jvcorredor/worktask)](https://goreportcard.com/report/github.com/jvcorredor/worktask)
-[![Release](https://img.shields.io/github/v/release/jvcorredor/worktask?label=release)](https://github.com/jvcorredor/worktask/releases)
-[![Docs](https://img.shields.io/badge/docs-jvcorredor.github.io%2Fworktask-blue)](https://jvcorredor.github.io/worktask/)
+[![Go Reference](https://pkg.go.dev/badge/github.com/jvcorredor/bytheway.svg)](https://pkg.go.dev/github.com/jvcorredor/bytheway)
+[![Go Report Card](https://goreportcard.com/badge/github.com/jvcorredor/bytheway)](https://goreportcard.com/report/github.com/jvcorredor/bytheway)
+[![Release](https://img.shields.io/github/v/release/jvcorredor/bytheway?label=release)](https://github.com/jvcorredor/bytheway/releases)
+[![Docs](https://img.shields.io/badge/docs-jvcorredor.github.io%2Fbytheway-blue)](https://jvcorredor.github.io/bytheway/)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](LICENSE)
 
 A Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and turn them into entrypoints for agentic work in Claude Code.
@@ -13,17 +13,17 @@ A Go CLI to capture and investigate fast inbounds — Slack threads, hallway ask
 ### From script
 
 ```
-curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
 ### From source
 
 ```
-go install github.com/jvcorredor/worktask@latest
+go install github.com/jvcorredor/bytheway@latest
 ```
 
-The binary lands in `$HOME/.local/bin` (or `$GOBIN` for `go install`) as `worktask`. See the [install reference](https://jvcorredor.github.io/worktask/install/) for env-var overrides and `$PATH` setup.
+The binary lands in `$HOME/.local/bin` (or `$GOBIN` for `go install`) as `btw`. See the [install reference](https://jvcorredor.github.io/bytheway/install/) for env-var overrides and `$PATH` setup.
 
 ## Documentation
 
-Full docs: <https://jvcorredor.github.io/worktask/>. The docs site is the canonical reference for subcommands, flags, JSON schema, file format, config keys, and agentic-usage patterns.
+Full docs: <https://jvcorredor.github.io/bytheway/>. The docs site is the canonical reference for subcommands, flags, JSON schema, file format, config keys, and agentic-usage patterns.

--- a/cmd/add_test.go
+++ b/cmd/add_test.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 	"testing"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestAddCmd_withTagsCreatesTaggedTask(t *testing.T) {

--- a/cmd/close_test.go
+++ b/cmd/close_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // TestCloseCmd_movesOpenTaskToClosedAndPrintsClosedID is the end-to-end
-// test for `worktask close <fragment>`: the open task file moves under
+// test for `btw close <fragment>`: the open task file moves under
 // closed/, the frontmatter gets a `completed:` stamp, and stdout reads
 // `closed <id>` (the verb matches the new subcommand name and the
 // inverse `reopen`).
@@ -68,7 +68,7 @@ func TestCloseCmd_movesOpenTaskToClosedAndPrintsClosedID(t *testing.T) {
 }
 
 // TestCompleteCmd_isRemoved enforces the no-alias acceptance criterion:
-// after the rename, `worktask complete <fragment>` must error out as an
+// after the rename, `btw complete <fragment>` must error out as an
 // unknown subcommand so that agents using the JSON envelope re-pin to
 // the new name rather than silently keep working against a deprecated
 // alias.

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -9,8 +9,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/config"
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/config"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var editCmd = &cobra.Command{

--- a/cmd/list.go
+++ b/cmd/list.go
@@ -5,10 +5,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/render"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/tag"
-	"github.com/jvcorredor/worktask/internal/tty"
+	"github.com/jvcorredor/bytheway/internal/render"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/tag"
+	"github.com/jvcorredor/bytheway/internal/tty"
 )
 
 const defaultClosedLimit = 20

--- a/cmd/list_test.go
+++ b/cmd/list_test.go
@@ -7,11 +7,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // TestListCmd_tagFlagFiltersToTaggedTasks is the end-to-end test for
-// `worktask list --tag bug`: only tasks with that tag appear; uppercase
+// `btw list --tag bug`: only tasks with that tag appear; uppercase
 // is normalized.
 func TestListCmd_tagFlagFiltersToTaggedTasks(t *testing.T) {
 	tmp := t.TempDir()
@@ -96,7 +96,7 @@ func TestListCmd_tagFlagInvalidValueErrors(t *testing.T) {
 }
 
 // TestListCmd_humanPipeModeIsPlain is the end-to-end pipe-mode test:
-// when stdout is a non-TTY writer (here, *bytes.Buffer), `worktask list`
+// when stdout is a non-TTY writer (here, *bytes.Buffer), `btw list`
 // must emit the plain `id  YYYY-MM-DD HH:MM  [tags]  description\n` rows
 // with no header and no ANSI escapes — the contract callers rely on for
 // piping into grep, awk, and other text tools.

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -11,11 +11,11 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/config"
-	"github.com/jvcorredor/worktask/internal/render"
-	"github.com/jvcorredor/worktask/internal/research"
-	"github.com/jvcorredor/worktask/internal/research/prompt"
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/config"
+	"github.com/jvcorredor/bytheway/internal/render"
+	"github.com/jvcorredor/bytheway/internal/research"
+	"github.com/jvcorredor/bytheway/internal/research/prompt"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var (

--- a/cmd/research_skip.go
+++ b/cmd/research_skip.go
@@ -3,10 +3,10 @@ package cmd
 import (
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
-// skipFlags is the subset of `worktask research` flags that decide which
+// skipFlags is the subset of `btw research` flags that decide which
 // tasks make it into the batch.
 type skipFlags struct {
 	all   bool

--- a/cmd/research_skip_test.go
+++ b/cmd/research_skip_test.go
@@ -4,7 +4,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestPartitionResearchCandidates(t *testing.T) {

--- a/cmd/research_tag.go
+++ b/cmd/research_tag.go
@@ -3,7 +3,7 @@ package cmd
 import (
 	"fmt"
 
-	"github.com/jvcorredor/worktask/internal/tag"
+	"github.com/jvcorredor/bytheway/internal/tag"
 )
 
 // validateResearchTag normalizes raw and verifies it is a syntactically

--- a/cmd/research_tag_test.go
+++ b/cmd/research_tag_test.go
@@ -8,7 +8,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // TestValidateResearchTag covers the pure helper that normalizes the
@@ -49,7 +49,7 @@ func TestValidateResearchTag(t *testing.T) {
 }
 
 // TestResearchCmd_tagFlagInvalidValueErrors verifies that an invalid
-// --tag value (per tag.Validate) is rejected by `worktask research`
+// --tag value (per tag.Validate) is rejected by `btw research`
 // before any work — no claude run, no writeback. Mirrors the
 // list-command guarantee.
 func TestResearchCmd_tagFlagInvalidValueErrors(t *testing.T) {
@@ -96,7 +96,7 @@ func TestResearchCmd_tagFlagInvalidValueErrors(t *testing.T) {
 	}
 }
 
-// TestResearchCmd_tagFlagRejectedInSingleMode verifies that `worktask
+// TestResearchCmd_tagFlagRejectedInSingleMode verifies that `btw
 // research <fragment> --tag x` errors out clearly rather than silently
 // ignoring --tag — surfacing the user mistake before any agent runs.
 func TestResearchCmd_tagFlagRejectedInSingleMode(t *testing.T) {

--- a/cmd/research_test.go
+++ b/cmd/research_test.go
@@ -12,8 +12,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // TestResearchCmd_batchForwardsCoordinatorOutputsIntoRender verifies the

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -1,4 +1,4 @@
-// Package cmd assembles the worktask cobra command tree.
+// Package cmd assembles the btw cobra command tree.
 //
 // The root command lives in this file as rootCmd; each subcommand —
 // add, list, show, close, reopen, edit, update, append, research —
@@ -23,8 +23,8 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/config"
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/config"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 const (
@@ -35,7 +35,7 @@ const (
 var format string
 
 var rootCmd = &cobra.Command{
-	Use:           "worktask",
+	Use:           "btw",
 	Short:         "Markdown-backed task CLI",
 	SilenceUsage:  true,
 	SilenceErrors: true,
@@ -47,7 +47,7 @@ func init() {
 
 var errExit = errors.New("exit")
 
-// Execute runs the worktask CLI: it dispatches the root cobra command,
+// Execute runs the btw CLI: it dispatches the root cobra command,
 // prints any error to stderr (suppressing the sentinel used to short-
 // circuit a subcommand without an extra error line), and exits the
 // process with status 1 on failure. It is the only entry point main.go

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -6,9 +6,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/render"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/tty"
+	"github.com/jvcorredor/bytheway/internal/render"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/tty"
 )
 
 var showCmd = &cobra.Command{

--- a/cmd/show_test.go
+++ b/cmd/show_test.go
@@ -10,8 +10,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/render"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/render"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // writeTaskFile encodes tk and writes it under openDir; tests rely on
@@ -28,7 +28,7 @@ func writeTaskFile(t *testing.T, openDir string, tk task.Task) {
 }
 
 // TestShowCmd_humanPipeModePassesRawBytes is the end-to-end pipe-mode test:
-// when stdout is a non-TTY writer (here, *bytes.Buffer), `worktask show
+// when stdout is a non-TTY writer (here, *bytes.Buffer), `btw show
 // <frag>` must emit the raw markdown file (frontmatter included) byte-for-byte
 // — the contract callers rely on for piping into editors and other tooling.
 func TestShowCmd_humanPipeModePassesRawBytes(t *testing.T) {
@@ -190,7 +190,7 @@ func TestShowCmd_humanNoMatchPipeModeIsPlain(t *testing.T) {
 	}
 }
 
-// TestShowCmd_jsonIncludesAbsolutePath asserts that `worktask show --format=json`
+// TestShowCmd_jsonIncludesAbsolutePath asserts that `btw show --format=json`
 // emits a top-level `path` field whose value is the absolute filesystem path
 // of the resolved task file. The test seeds an open-task file on disk, runs
 // `show <id> --format=json`, and parses the stdout JSON to compare `path`

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -5,9 +5,9 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/jvcorredor/worktask/internal/render"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/tty"
+	"github.com/jvcorredor/bytheway/internal/render"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/tty"
 )
 
 var tagCmd = &cobra.Command{

--- a/cmd/tag_test.go
+++ b/cmd/tag_test.go
@@ -8,11 +8,11 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // TestTagLsCmd_jsonModeReturnsTagsEnvelope is the end-to-end test for
-// `worktask --format=json tag ls`: stdout is the {"tags": [...]} envelope
+// `btw --format=json tag ls`: stdout is the {"tags": [...]} envelope
 // with entries sorted alphabetically.
 func TestTagLsCmd_jsonModeReturnsTagsEnvelope(t *testing.T) {
 	tmp := t.TempDir()
@@ -63,7 +63,7 @@ func TestTagLsCmd_jsonModeReturnsTagsEnvelope(t *testing.T) {
 }
 
 // TestTagLsCmd_humanModeEmitsSpaceSeparatedLine is the end-to-end test
-// for `worktask tag ls`: in human mode, output is a single line of
+// for `btw tag ls`: in human mode, output is a single line of
 // "name (count)" entries with no header, no ANSI escapes — the contract
 // pipe-mode callers rely on for grep/awk.
 func TestTagLsCmd_humanModeEmitsSpaceSeparatedLine(t *testing.T) {
@@ -271,7 +271,7 @@ func TestTagLsCmd_allFlagIncludesOpenAndClosed(t *testing.T) {
 }
 
 // TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage is the
-// end-to-end test for `worktask tag rm <fragment> <tag>`.
+// end-to-end test for `btw tag rm <fragment> <tag>`.
 func TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)
@@ -326,7 +326,7 @@ func TestTagRmCmd_removesTagFromOpenTaskAndPrintsRemovedMessage(t *testing.T) {
 }
 
 // TestTagAddCmd_addsTagToOpenTaskAndPrintsTaggedID is the end-to-end
-// test for `worktask tag add <fragment> <tag>`.
+// test for `btw tag add <fragment> <tag>`.
 func TestTagAddCmd_addsTagToOpenTaskAndPrintsTaggedID(t *testing.T) {
 	tmp := t.TempDir()
 	t.Setenv("XDG_DATA_HOME", tmp)

--- a/cmd/version.go
+++ b/cmd/version.go
@@ -6,12 +6,12 @@ import (
 
 	"github.com/spf13/cobra"
 
-	intversion "github.com/jvcorredor/worktask/internal/version"
+	intversion "github.com/jvcorredor/bytheway/internal/version"
 )
 
 var versionCmd = &cobra.Command{
 	Use:   "version",
-	Short: "Print the worktask version",
+	Short: "Print the btw version",
 	Args:  cobra.NoArgs,
 	RunE: func(cmd *cobra.Command, args []string) error {
 		info := intversion.Get()
@@ -31,7 +31,7 @@ var versionCmd = &cobra.Command{
 			_, err = cmd.OutOrStdout().Write(data)
 			return err
 		case formatHuman:
-			_, err := fmt.Fprintf(cmd.OutOrStdout(), "worktask %s (commit %s, built %s)\n", info.Version, info.Commit, info.Date)
+			_, err := fmt.Fprintf(cmd.OutOrStdout(), "btw %s (commit %s, built %s)\n", info.Version, info.Commit, info.Date)
 			return err
 		default:
 			return fmt.Errorf("unknown format: %s", format)

--- a/cmd/version_test.go
+++ b/cmd/version_test.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 	"testing"
 
-	intversion "github.com/jvcorredor/worktask/internal/version"
+	intversion "github.com/jvcorredor/bytheway/internal/version"
 )
 
 // setVersionForTest seeds the internal/version package's ldflags landing
@@ -49,7 +49,7 @@ func runVersionCmd(t *testing.T, fmtFlag string) (stdout, stderr bytes.Buffer) {
 
 // TestRootCmdVersionFlag is the cobra wiring test: after the cmd package
 // init runs, rootCmd.Version must be populated from version.Get(), so
-// `worktask --version` and `worktask -v` print a meaningful line via
+// `btw --version` and `btw -v` print a meaningful line via
 // cobra's built-in version flag handling.
 func TestRootCmdVersionFlag(t *testing.T) {
 	setVersionForTest(t, "v9.9.9", "abc1234", "2026-05-03T12:00:00Z")

--- a/cmd/version_vars.go
+++ b/cmd/version_vars.go
@@ -1,15 +1,15 @@
 package cmd
 
 import (
-	intversion "github.com/jvcorredor/worktask/internal/version"
+	intversion "github.com/jvcorredor/bytheway/internal/version"
 )
 
 // Version, Commit, and Date are the cobra-side ldflags landing zone.
 // Release builds inject them via
 //
-//	go build -ldflags="-X github.com/jvcorredor/worktask/cmd.Version=v1.2.3 \
-//	                   -X github.com/jvcorredor/worktask/cmd.Commit=$SHA \
-//	                   -X github.com/jvcorredor/worktask/cmd.Date=$ISO8601"
+//	go build -ldflags="-X github.com/jvcorredor/bytheway/cmd.Version=v1.2.3 \
+//	                   -X github.com/jvcorredor/bytheway/cmd.Commit=$SHA \
+//	                   -X github.com/jvcorredor/bytheway/cmd.Date=$ISO8601"
 //
 // They mirror the convention of putting build identity at the binary's
 // command package; syncVersion forwards them into internal/version where

--- a/docs/adr/0001-tag-model.md
+++ b/docs/adr/0001-tag-model.md
@@ -6,11 +6,11 @@ Accepted
 
 ## Context
 
-Worktask captures fast inbounds and shepherds them through a soak phase before investigation fires. During soak the user accumulates context on a captured task — `append`, `update`, and `edit` mutate the body — but those primitives don't answer *what kind of inbound this is*. A bug report soaks differently from a leadership question; an "incident postmortem" capture wants different downstream handling from a "Q3 roadmap decision" capture. Without a triage primitive, the soak-phase backlog is an undifferentiated stream and the user has to re-read each task to remember its shape.
+Bytheway captures fast inbounds and shepherds them through a soak phase before investigation fires. During soak the user accumulates context on a captured task — `append`, `update`, and `edit` mutate the body — but those primitives don't answer *what kind of inbound this is*. A bug report soaks differently from a leadership question; an "incident postmortem" capture wants different downstream handling from a "Q3 roadmap decision" capture. Without a triage primitive, the soak-phase backlog is an undifferentiated stream and the user has to re-read each task to remember its shape.
 
 Tags are the soak-phase triage label that fills that gap. The user attaches a short, lowercase identifier at capture time — `bug`, `urgent`, `roadmap`, `incident` — to mark intent without committing to a folder layout, a status enum, or a separate metadata store. The label travels with the task in its frontmatter, so it survives the file-based storage format and stays accessible to both human users and programmatic consumers (agents, scripts).
 
-A secondary use case follows from the same primitive: once a cohort of tasks carries the same label, batch-routing for sweeps is cheap. `worktask research --tag <tag>` fires investigation across the cohort in one pass; `worktask list --tag <tag>` produces a soak-phase backlog view scoped to one kind of inbound. These flows reuse the triage label rather than reintroducing a categorisation system.
+A secondary use case follows from the same primitive: once a cohort of tasks carries the same label, batch-routing for sweeps is cheap. `btw research --tag <tag>` fires investigation across the cohort in one pass; `btw list --tag <tag>` produces a soak-phase backlog view scoped to one kind of inbound. These flows reuse the triage label rather than reintroducing a categorisation system.
 
 The design must fit the existing frontmatter codec without breaking backward compatibility.
 

--- a/docs/adr/0002-research-coordinator.md
+++ b/docs/adr/0002-research-coordinator.md
@@ -23,7 +23,7 @@ path. The closure that bridges pool and runner reaches into the sidecar
 on every dispatch. The construct is a workaround caused by orchestration
 state living in `cmd/`, above the layer that should own it.
 
-Tracking issue [#85](https://github.com/jvcorredor/worktask/issues/85)
+Tracking issue [#85](https://github.com/jvcorredor/bytheway/issues/85)
 asked for a research spike: investigate whether a `ResearchCoordinator`
 module — with injected dependencies and a clean test surface — can
 absorb the duplication and dissolve `itemMeta`.
@@ -203,7 +203,7 @@ intentional change in Consequences.
   The current batch path silently swallows them; the new path turns
   them into `failed` results so a "research run reported success but
   the task body wasn't updated" silently doesn't happen. Single-task
-  callers (`worktask research <fragment>`) see the writeback error
+  callers (`btw research <fragment>`) see the writeback error
   reflected in the JSON line's `error` field.
 - **Behavior change: per-task render failures no longer abort the
   batch.** A malformed body that breaks the template for one task no
@@ -216,8 +216,8 @@ intentional change in Consequences.
 
 ## References
 
-- Spike issue: [#85](https://github.com/jvcorredor/worktask/issues/85)
-- Prototype branch: `worktask-85-research-coordinator-spike` —
+- Spike issue: [#85](https://github.com/jvcorredor/bytheway/issues/85)
+- Prototype branch: `bytheway-85-research-coordinator-spike` —
   contains the Coordinator package and three indicative tests
   (`TestRunOne_findings_appliesWriteback`,
   `TestRunOne_failed_skipsWriteback`,

--- a/docs/astro.config.mjs
+++ b/docs/astro.config.mjs
@@ -3,17 +3,17 @@ import starlight from '@astrojs/starlight';
 
 export default defineConfig({
   site: 'https://jvcorredor.github.io',
-  base: '/worktask',
+  base: '/bytheway',
   integrations: [
     starlight({
-      title: 'worktask',
+      title: 'bytheway',
       description:
         'A Go CLI for task management designed primarily for LLM-agent consumption (Claude Code), usable as a normal terminal CLI.',
       social: [
-        { icon: 'github', label: 'GitHub', href: 'https://github.com/jvcorredor/worktask' },
+        { icon: 'github', label: 'GitHub', href: 'https://github.com/jvcorredor/bytheway' },
       ],
       editLink: {
-        baseUrl: 'https://github.com/jvcorredor/worktask/edit/main/docs/',
+        baseUrl: 'https://github.com/jvcorredor/bytheway/edit/main/docs/',
       },
       lastUpdated: true,
       sidebar: [

--- a/docs/package.json
+++ b/docs/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "worktask-docs",
+  "name": "bytheway-docs",
   "version": "0.0.0",
   "private": true,
   "type": "module",

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
-# worktask installer — POSIX, no bashisms.
+# btw installer — POSIX, no bashisms.
 #
-# Usage:  curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+# Usage:  curl -fsSL https://jvcorredor.github.io/btw/install.sh | sh
 #
 # Env vars:
 #   INSTALL_DIR   destination directory (default: $HOME/.local/bin)
@@ -9,7 +9,7 @@
 
 set -eu
 
-REPO='jvcorredor/worktask'
+REPO='jvcorredor/bytheway'
 RELEASES_BASE="https://github.com/${REPO}/releases/download"
 LATEST_API="https://api.github.com/repos/${REPO}/releases/latest"
 
@@ -80,14 +80,14 @@ main() {
     version=$(resolve_version)
     platform=$(detect_platform)
     tag="v${version}"
-    tarball="worktask_${version}_${platform}.tar.gz"
+    tarball="bytheway_${version}_${platform}.tar.gz"
     tarball_url="${RELEASES_BASE}/${tag}/${tarball}"
     checksums_url="${RELEASES_BASE}/${tag}/checksums.txt"
 
-    install_path="$INSTALL_DIR/worktask"
+    install_path="$INSTALL_DIR/btw"
     existing=$(installed_version "$install_path")
 
-    workdir=$(mktemp -d "${TMPDIR:-/tmp}/worktask-install.XXXXXX")
+    workdir=$(mktemp -d "${TMPDIR:-/tmp}/btw-install.XXXXXX")
     trap 'rm -rf "$workdir"' EXIT
 
     printf 'Downloading %s\n' "$tarball"
@@ -101,17 +101,17 @@ main() {
     actual=$(sha256_hash "$workdir/$tarball")
     [ "$expected" = "$actual" ] || die "checksum mismatch for $tarball: expected $expected, got $actual"
 
-    tar -xzf "$workdir/$tarball" -C "$workdir" worktask \
-        || die "failed to extract worktask from $tarball"
+    tar -xzf "$workdir/$tarball" -C "$workdir" btw \
+        || die "failed to extract btw from $tarball"
 
     mkdir -p "$INSTALL_DIR"
     if [ -n "$existing" ] && [ "$existing" != "$version" ]; then
-        printf 'Upgrading worktask from %s to %s\n' "$existing" "$version"
+        printf 'Upgrading btw from %s to %s\n' "$existing" "$version"
     fi
-    mv "$workdir/worktask" "$install_path"
+    mv "$workdir/btw" "$install_path"
     chmod +x "$install_path"
 
-    printf 'Installed worktask %s to %s\n' "$version" "$install_path"
+    printf 'Installed btw %s to %s\n' "$version" "$install_path"
 
     print_path_hint_if_needed
 }

--- a/docs/src/content/docs/agentic-recipes.md
+++ b/docs/src/content/docs/agentic-recipes.md
@@ -1,22 +1,22 @@
 ---
 title: Agentic recipes
-description: The capture / soak / investigate / hand off funnel as recipes against existing worktask primitives.
+description: The capture / soak / investigate / hand off funnel as recipes against existing bytheway primitives.
 ---
 
-`worktask` is built around a four-stage funnel: **capture** a fast inbound, **soak** it as more context arrives, **investigate** once the seed material is dense enough, and **hand off** the investigated brief to a downstream skill that shapes it.
+`btw` is built around a four-stage funnel: **capture** a fast inbound, **soak** it as more context arrives, **investigate** once the seed material is dense enough, and **hand off** the investigated brief to a downstream skill that shapes it.
 
 The CLI exposes user-triggered primitives for capture and investigation. It does not chain stages together — every stage fires when you (or the calling agent) say so. There is no `capture` composite verb, no `add --research` flag, and no shipped wrapper skill. The recipes below show the canonical end-to-end pattern using only the primitives the binary already exposes.
 
 ## Role boundary
 
-Worktask owns **capture** and **investigation**. Shaping the investigated brief into a plan, a PRD, an issue, or a draft message — and delivering it to wherever it needs to go — are downstream responsibilities. Skills like `/grill-me` and `/grill-with-docs` are typical handoff targets; worktask's job ends when it has written investigated starting points back into the task body.
+Bytheway owns **capture** and **investigation**. Shaping the investigated brief into a plan, a PRD, an issue, or a draft message — and delivering it to wherever it needs to go — are downstream responsibilities. Skills like `/grill-me` and `/grill-with-docs` are typical handoff targets; bytheway's job ends when it has written investigated starting points back into the task body.
 
 ## 1. Capture
 
 Catch the inbound before it disappears. One line of intent is enough — slug, ID, and timestamp are generated for you.
 
 ```
-$ worktask add "slack thread from leadership about renewal churn"
+$ btw add "slack thread from leadership about renewal churn"
 added 1e3900e4
 ```
 
@@ -31,25 +31,25 @@ Soak is the gap between capture and investigation. As more context trickles in �
 Append free-form context with [`append`](./cli.md#append):
 
 ```
-$ worktask append 1e3900e4 "ARR impact called out in Q1 board deck — see drive link in #renewal-ops"
-$ worktask append 1e3900e4 "engineering counterpoint: cohort 2024-Q3 was a one-off, not a trend"
+$ bytheway append 1e3900e4 "ARR impact called out in Q1 board deck — see drive link in #renewal-ops"
+$ bytheway append 1e3900e4 "engineering counterpoint: cohort 2024-Q3 was a one-off, not a trend"
 ```
 
 Replace the canonical description with [`update`](./cli.md#update) when the framing of the task itself shifts:
 
 ```
-$ worktask update 1e3900e4 "renewal churn — cohort 2024-Q3 anomaly vs. trend"
+$ bytheway update 1e3900e4 "renewal churn — cohort 2024-Q3 anomaly vs. trend"
 ```
 
-For larger edits — restructuring the body, pasting a long quote — open the file in your editor with [`edit`](./cli.md#edit). The CLI hands off to `$EDITOR` directly; agents validate the fragment with `show` and then ask the user to run `worktask edit <id>` from their own shell, since `syscall.Exec` is unusable from an agent shell.
+For larger edits — restructuring the body, pasting a long quote — open the file in your editor with [`edit`](./cli.md#edit). The CLI hands off to `$EDITOR` directly; agents validate the fragment with `show` and then ask the user to run `btw edit <id>` from their own shell, since `syscall.Exec` is unusable from an agent shell.
 
 Tagging is optional and belongs to soak. Tags are triage labels, not generic categorization — use them when you want to group captures for a later batch sweep:
 
 ```
-$ worktask tag add 1e3900e4 renewal
+$ btw tag add 1e3900e4 renewal
 ```
 
-You can later scope investigation to that triage bucket with `worktask research --tag renewal` (see below).
+You can later scope investigation to that triage bucket with `btw research --tag renewal` (see below).
 
 ### When *not* to fire research yet
 
@@ -68,22 +68,22 @@ Once the seed is dense enough, fire [`research`](./cli.md#research). The CLI spa
 Single task:
 
 ```
-$ worktask research 1e3900e4
+$ btw research 1e3900e4
 ```
 
 Batch every open task that has not been researched yet:
 
 ```
-$ worktask research
+$ btw research
 ```
 
 Sweep just the soak-triage bucket you tagged earlier:
 
 ```
-$ worktask research --tag renewal
+$ btw research --tag renewal
 ```
 
-Research runs are unattended and can take minutes per task. From a slash command, dispatch via a background bash and return an immediate ack to the user; the harness notifies the agent when the run lands. The vendored [reference slash command](./examples/worktask-slash-command.md) shows the full pattern.
+Research runs are unattended and can take minutes per task. From a slash command, dispatch via a background bash and return an immediate ack to the user; the harness notifies the agent when the run lands. The vendored [reference slash command](./examples/bytheway-slash-command.md) shows the full pattern.
 
 ## 4. Hand off
 
@@ -95,17 +95,17 @@ After investigation, the task body carries the agent's findings, and the YAML fr
 A handoff recipe pulls the body and the log path out of `show` and feeds them to the downstream skill:
 
 ```
-$ worktask --format=json show 1e3900e4 | jq -r .body
-$ worktask --format=json show 1e3900e4 | jq -r .last_research_log
-$ worktask --format=json show 1e3900e4 | jq -r .last_researched
+$ btw --format=json show 1e3900e4 | jq -r .body
+$ btw --format=json show 1e3900e4 | jq -r .last_research_log
+$ btw --format=json show 1e3900e4 | jq -r .last_researched
 ```
 
-A downstream slash command — `/grill-me`, `/grill-with-docs`, or any project-local equivalent — reads those fields, optionally `cat`s the log, and turns the investigated material into a plan, a PRD, an issue, or a draft message. That shaping step is outside worktask's scope by design.
+A downstream slash command — `/grill-me`, `/grill-with-docs`, or any project-local equivalent — reads those fields, optionally `cat`s the log, and turns the investigated material into a plan, a PRD, an issue, or a draft message. That shaping step is outside bytheway's scope by design.
 
 Branching on whether a task has been investigated is a one-liner against the same JSON:
 
 ```
-$ worktask --format=json show 1e3900e4 | jq -e 'has("last_researched")'
+$ btw --format=json show 1e3900e4 | jq -e 'has("last_researched")'
 ```
 
 Returns 0 if the task has been researched, non-zero otherwise — useful for a wrapper that wants to soak-or-handoff dispatch without a second CLI call.
@@ -113,5 +113,5 @@ Returns 0 if the task has been researched, non-zero otherwise — useful for a w
 ## Where to go next
 
 - [Agentic usage](./agentic.md) — JSON schema, error envelopes, and the slash-command dispatch pattern.
-- [Reference slash command](./examples/worktask-slash-command.md) — the vendored Claude Code slash command, end-to-end.
+- [Reference slash command](./examples/bytheway-slash-command.md) — the vendored Claude Code slash command, end-to-end.
 - [CLI reference](./cli.md) — every primitive cited above, with flags and examples.

--- a/docs/src/content/docs/agentic.md
+++ b/docs/src/content/docs/agentic.md
@@ -1,9 +1,9 @@
 ---
 title: Agentic usage
-description: Using worktask from an LLM agent — JSON schema, error envelopes, and the reference slash command pattern.
+description: Using bytheway from an LLM agent — JSON schema, error envelopes, and the reference slash command pattern.
 ---
 
-`worktask` is built primarily as a tool for an LLM agent (Claude Code) to call from a thin slash command. Match resolution, ID generation, slug generation, and formatting all live in the CLI so the agent never has to read or rewrite task files itself. A read-only `list` or `show` costs the agent only the bytes the CLI prints, not the entire file store.
+`btw` is built primarily as a tool for an LLM agent (Claude Code) to call from a thin slash command. Match resolution, ID generation, slug generation, and formatting all live in the CLI so the agent never has to read or rewrite task files itself. A read-only `list` or `show` costs the agent only the bytes the CLI prints, not the entire file store.
 
 This page documents the contract between the CLI and an agent wrapper: the JSON schema returned by every subcommand, the error envelopes the agent must branch on, and the dispatch pattern the reference slash command uses.
 
@@ -49,17 +49,17 @@ The reference slash command for Claude Code is a thin wrapper. It does not read 
 | Subcommands | How the wrapper invokes them | Notes |
 |-------------|------------------------------|-------|
 | `add`, `list`, `show`, `update`, `append`, `close`, `reopen` | Shell out with `--format=json`. On exit 0, pass success output through. On non-zero exit, branch on the `error` discriminator. | Uniform shape across all of them. |
-| `edit` | Does **not** shell out. Validate the fragment via `show`, then tell the user to run `worktask edit <id>` from their own shell. | The binary `syscall.Exec`s `$EDITOR`, which is unusable from an agent shell. |
+| `edit` | Does **not** shell out. Validate the fragment via `show`, then tell the user to run `btw edit <id>` from their own shell. | The binary `syscall.Exec`s `$EDITOR`, which is unusable from an agent shell. |
 
 ## Reference slash command
 
-A vendored reference implementation of the Claude Code slash command lives in this repo at `docs/src/content/docs/examples/worktask-slash-command.md`. The full source is rendered on the [Reference slash command](./examples/worktask-slash-command.md) page — read it end-to-end to see the dispatch table, error-envelope branching, and the `edit` / `research` special cases in their working form.
+A vendored reference implementation of the Claude Code slash command lives in this repo at `docs/src/content/docs/examples/bytheway-slash-command.md`. The full source is rendered on the [Reference slash command](./examples/bytheway-slash-command.md) page — read it end-to-end to see the dispatch table, error-envelope branching, and the `edit` / `research` special cases in their working form.
 
 :::tip[Curl the canonical source]
 For templating into another agent, fetch the raw markdown directly:
 
 ```
-curl -fsSL https://raw.githubusercontent.com/jvcorredor/worktask/main/docs/src/content/docs/examples/worktask-slash-command.md
+curl -fsSL https://raw.githubusercontent.com/jvcorredor/bytheway/main/docs/src/content/docs/examples/bytheway-slash-command.md
 ```
 
 The file's frontmatter is Claude-Code-compatible (`description:`, `argument-hint:`); the additional `title:` key Starlight needs is ignored by Claude Code, so the raw download is a drop-in slash command source.
@@ -67,10 +67,10 @@ The file's frontmatter is Claude-Code-compatible (`description:`, `argument-hint
 
 ## Research-agent allowlist
 
-`worktask research` spawns a headless Claude Code subagent under `--permission-mode=bypassPermissions`, with an explicit `--allowed-tools` list. That list is the security boundary, and it is config-driven on a per-machine basis: the shipped binary contributes a vanilla baseline of five built-in read-only tools (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`), and the user's `config.toml` extends it via [`research_extra_tools`](./config.md#research_extra_tools). MCP tool names and pattern-restricted `Bash(...)` invocations belong in the config, not in the binary.
+`btw research` spawns a headless Claude Code subagent under `--permission-mode=bypassPermissions`, with an explicit `--allowed-tools` list. That list is the security boundary, and it is config-driven on a per-machine basis: the shipped binary contributes a vanilla baseline of five built-in read-only tools (`Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`), and the user's `config.toml` extends it via [`research_extra_tools`](./config.md#research_extra_tools). MCP tool names and pattern-restricted `Bash(...)` invocations belong in the config, not in the binary.
 
-If you are wrapping `worktask research` from another agent, you do not need to thread tool names through the wrapper — they live in the operator's `config.toml`. The CLI surface (subcommand name, flags, JSON output, exit-code envelope) is unchanged by the allowlist mechanism.
+If you are wrapping `btw research` from another agent, you do not need to thread tool names through the wrapper — they live in the operator's `config.toml`. The CLI surface (subcommand name, flags, JSON output, exit-code envelope) is unchanged by the allowlist mechanism.
 
 ## Skills
 
-Claude Code also exposes a wrapper surface called *skills* alongside slash commands. There is no shipped `worktask` skill, and there will not be one — the soak phase between capture and investigation requires explicit user control over when investigation fires, which a wrapper that auto-chains stages would erase. The canonical end-to-end pattern is documented as recipes against existing CLI primitives on the [Agentic recipes](./agentic-recipes.md) page.
+Claude Code also exposes a wrapper surface called *skills* alongside slash commands. There is no shipped `btw` skill, and there will not be one — the soak phase between capture and investigation requires explicit user control over when investigation fires, which a wrapper that auto-chains stages would erase. The canonical end-to-end pattern is documented as recipes against existing CLI primitives on the [Agentic recipes](./agentic-recipes.md) page.

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -1,34 +1,34 @@
 ---
 title: CLI reference
-description: Subcommand reference for the worktask CLI — flags, examples, and match-resolution behavior.
+description: Subcommand reference for the bytheway CLI — flags, examples, and match-resolution behavior.
 ---
 
-Every subcommand `worktask` exposes is documented on this page. For the on-disk shape of task files, see [File & storage format](./storage.md). For JSON output and error envelopes, see [Agentic usage](./agentic.md).
+Every subcommand `btw` exposes is documented on this page. For the on-disk shape of task files, see [File & storage format](./storage.md). For JSON output and error envelopes, see [Agentic usage](./agentic.md).
 
 ## Global flags
 
 `--format=human|json` (default `human`).
 
-JSON output is intended for agentic consumers; the schema is documented as stable. Human output is the default and is what you see when running `worktask` directly in a terminal.
+JSON output is intended for agentic consumers; the schema is documented as stable. Human output is the default and is what you see when running `btw` directly in a terminal.
 
 `--version` (alias `-v`) prints the binary's version on a single line and exits — see the [`version`](#version) subcommand below for the underlying resolution rules.
 
 ## Subcommands at a glance
 
 ```
-worktask add <description>
-worktask list [--all] [--closed] [--limit N] [--tag TAG]
-worktask show <fragment>
-worktask update <fragment> <new description>
-worktask append <fragment> <text>
-worktask close <fragment>
-worktask reopen <fragment>
-worktask edit <fragment>
-worktask tag add <fragment> <tag>
-worktask tag rm <fragment> <tag>
-worktask tag ls [--all] [--closed]
-worktask research [<fragment>]
-worktask version
+btw add <description>
+btw list [--all] [--closed] [--limit N] [--tag TAG]
+btw show <fragment>
+bytheway update <fragment> <new description>
+bytheway append <fragment> <text>
+btw close <fragment>
+bytheway reopen <fragment>
+btw edit <fragment>
+btw tag add <fragment> <tag>
+btw tag rm <fragment> <tag>
+btw tag ls [--all] [--closed]
+btw research [<fragment>]
+btw version
 ```
 
 `<fragment>` is anything that resolves to a single task. See [Match resolution](#match-resolution) below.
@@ -40,7 +40,7 @@ There is no `delete` subcommand by design. Removing a task means `rm` against th
 Creates a new task in `open/`, prints `added <id>`.
 
 ```
-$ worktask add buy milk
+$ btw add buy milk
 added abcdef12
 ```
 
@@ -58,11 +58,11 @@ Flags:
 - `--tag TAG` filters to tasks carrying the tag (single value, exact match after lowercase normalization). Composes as logical AND with `--all`/`--closed`. A non-matching tag returns an empty list with no error; an invalid tag value (whitespace, uppercase that doesn't normalize cleanly, characters outside `[a-z0-9-]`) is rejected.
 
 ```
-$ worktask list
-$ worktask list --all
-$ worktask list --closed --limit 50
-$ worktask list --tag bug
-$ worktask list --tag infra --all
+$ btw list
+$ btw list --all
+$ btw list --closed --limit 50
+$ btw list --tag bug
+$ btw list --tag infra --all
 ```
 
 In `--format=human`, the rendering is TTY-aware:
@@ -84,20 +84,20 @@ In `--format=human`, the rendering is TTY-aware:
 In `--format=json`, it prints a JSON object with `id`, `created`, `description`, `body`, `path`, and (if closed) `completed`. When the task has been researched, the object also carries `last_researched` (RFC 3339 UTC) and `last_research_log` (absolute path to the latest run's JSONL log); both are omitted when un-researched. `path` is the absolute, cleaned filesystem path of the task file; symlinks in the configured tasks directory are preserved verbatim. JSON output is unchanged by TTY detection.
 
 ```
-$ worktask show milk
-$ worktask --format=json show abcdef12
-$ worktask --format=json show abcdef12 | jq -r .path               # the file on disk
-$ worktask --format=json show abcdef12 | jq -r .last_research_log  # latest research log
+$ btw show milk
+$ btw --format=json show abcdef12
+$ btw --format=json show abcdef12 | jq -r .path               # the file on disk
+$ btw --format=json show abcdef12 | jq -r .last_research_log  # latest research log
 ```
 
-Older releases shipped a dedicated `worktask research-log <fragment>` subcommand that printed only the latest research-log path; it has been removed in favour of the `show --format=json | jq -r .last_research_log` form above. Existing scripts that called `worktask research-log` should switch to that pipeline.
+Older releases shipped a dedicated `btw research-log <fragment>` subcommand that printed only the latest research-log path; it has been removed in favour of the `show --format=json | jq -r .last_research_log` form above. Existing scripts that called `btw research-log` should switch to that pipeline.
 
 ## `update`
 
 Replaces the first body line — the canonical description — without touching frontmatter, ID, slug, or filename.
 
 ```
-$ worktask update milk buy oat milk instead
+$ bytheway update milk buy oat milk instead
 ```
 
 ## `append`
@@ -105,7 +105,7 @@ $ worktask update milk buy oat milk instead
 Adds text to the body of a task, preserving everything above it.
 
 ```
-$ worktask append milk remember the brand
+$ bytheway append milk remember the brand
 ```
 
 ## `close`
@@ -113,7 +113,7 @@ $ worktask append milk remember the brand
 Moves the file from `open/` to `closed/` via `os.Rename` and stamps `completed:` into the frontmatter.
 
 ```
-$ worktask close milk
+$ btw close milk
 ```
 
 ## `reopen`
@@ -121,7 +121,7 @@ $ worktask close milk
 The inverse of `close`: moves the file back to `open/` and clears the `completed:` field.
 
 ```
-$ worktask reopen milk
+$ bytheway reopen milk
 ```
 
 ## `tag add`
@@ -129,7 +129,7 @@ $ worktask reopen milk
 Adds a tag to an existing task. The tag is normalized (lower-cased, trimmed) and validated against `[a-z0-9-]` up to 40 characters. Re-running with the same tag is a no-op.
 
 ```
-$ worktask tag add milk urgent
+$ btw tag add milk urgent
 tagged abcdef12 with urgent
 ```
 
@@ -138,7 +138,7 @@ tagged abcdef12 with urgent
 Removes a tag from an existing task. Re-running with an absent tag is a no-op. When the last tag is removed, the `tags:` frontmatter line is omitted entirely.
 
 ```
-$ worktask tag rm milk urgent
+$ btw tag rm milk urgent
 removed urgent from abcdef12
 ```
 
@@ -156,14 +156,14 @@ Default is open tasks only — same semantics as [`list`](#list).
 In `--format=human`, output is a single space-padded line of `name (count)` entries, no header, no ANSI escapes. An empty corpus emits a blank line.
 
 ```
-$ worktask tag ls
+$ btw tag ls
 bug (3)  infra (5)  urgent (2)
 ```
 
 In `--format=json`, output is `{"tags": [{"name": ..., "count": ...}, ...]}`. The `tags` key is always present (empty array when none) so consumers can `jq '.tags'` without null-checking.
 
 ```
-$ worktask --format=json tag ls
+$ btw --format=json tag ls
 {
   "tags": [
     {"name": "bug",    "count": 3},
@@ -178,18 +178,18 @@ $ worktask --format=json tag ls
 `syscall.Exec`s `$EDITOR` (or the configured override, falling back to `vi`) on the resolved task path. See [Configuration](./config.md) for editor resolution.
 
 ```
-$ worktask edit milk
+$ btw edit milk
 ```
 
-This command is not usable from an agent shell because it replaces the calling process with the editor. The reference slash command instructs the user to run `worktask edit <id>` from their own shell instead.
+This command is not usable from an agent shell because it replaces the calling process with the editor. The reference slash command instructs the user to run `btw edit <id>` from their own shell instead.
 
 ## `research`
 
 Spawns a headless Claude Code agent to gather context for one task or sweep every open task. The agent runs unattended with `--permission-mode=bypassPermissions`; the security boundary is the `--allowed-tools` list passed to it.
 
 ```
-$ worktask research milk        # research a single task
-$ worktask research              # batch-research every open task
+$ btw research milk        # research a single task
+$ btw research              # batch-research every open task
 ```
 
 Flags:
@@ -205,7 +205,7 @@ The shipped binary's `--allowed-tools` baseline contains five built-in read-only
 
 ### Batch outcome reporting
 
-In a batch run (`worktask research` or `worktask research --all`), every task makes it into the final summary, even when prep- or post-run plumbing fails. Two cases that previously fell through the cracks now surface as `failed` outcomes:
+In a batch run (`btw research` or `btw research --all`), every task makes it into the final summary, even when prep- or post-run plumbing fails. Two cases that previously fell through the cracks now surface as `failed` outcomes:
 
 - **Writeback errors** (the agent succeeded but the cmd could not append the Research section, set the `last_researched` frontmatter, or append the worklog line — for example, the task file went missing mid-run, or the worklog directory is unwritable) emit a `task_failed` event and a `failed` row in the summary. The agent's original summary text is preserved in the row's `summary` field; the writeback error message goes into `error`. Previously these were silently reported as if the writeback had succeeded.
 - **Per-task `prompt.Render` failures during prep** (a malformed override template, or a task whose frontmatter does not satisfy a custom template's field references) emit a synthetic `task_failed` event for that task and a `failed` row in the summary. Other tasks in the batch still run. Previously a single render failure aborted the whole sweep before any task ran.
@@ -216,13 +216,13 @@ JSON output is documented in [Agentic usage](./agentic.md).
 
 ## `version`
 
-Prints the binary's build identity. The same identity is what `worktask --version` and `worktask -v` report on a single line via cobra's built-in version flag.
+Prints the binary's build identity. The same identity is what `btw --version` and `btw -v` report on a single line via cobra's built-in version flag.
 
 ```
-$ worktask version
-worktask v1.2.3 (commit abcdef1, built 2026-05-03T10:00:00Z)
+$ btw version
+bytheway v1.2.3 (commit abcdef1, built 2026-05-03T10:00:00Z)
 
-$ worktask --format=json version
+$ btw --format=json version
 {
   "version": "v1.2.3",
   "commit": "abcdef1",
@@ -235,7 +235,7 @@ The JSON schema is `{"version": string, "commit": string, "date": string, "sourc
 
 ## Match resolution
 
-For commands that take `<fragment>`, `worktask` tries strategies in order and stops at the first one that yields any matches:
+For commands that take `<fragment>`, `btw` tries strategies in order and stops at the first one that yields any matches:
 
 1. ID exact
 2. ID prefix

--- a/docs/src/content/docs/config.md
+++ b/docs/src/content/docs/config.md
@@ -1,9 +1,9 @@
 ---
 title: Configuration
-description: Configuring worktask via tasks_dir, editor, research_model, research_prompt_path, research_extra_tools, XDG paths, and resolution order.
+description: Configuring bytheway via tasks_dir, editor, research_model, research_prompt_path, research_extra_tools, XDG paths, and resolution order.
 ---
 
-`worktask` is configured via a single optional TOML file. There is no `init` step: if the file is absent, `worktask` runs on defaults. If it is present, every key in it is optional.
+`btw` is configured via a single optional TOML file. There is no `init` step: if the file is absent, `btw` runs on defaults. If it is present, every key in it is optional.
 
 ## File path
 
@@ -27,11 +27,11 @@ research_extra_tools = [
 
 ## `tasks_dir`
 
-Where task files live. See the data directory layout in [File & storage format](./storage.md). When unset, `worktask` uses `$XDG_DATA_HOME/worktask/`, falling back to `~/.local/share/worktask/`.
+Where task files live. See the data directory layout in [File & storage format](./storage.md). When unset, `btw` uses `$XDG_DATA_HOME/worktask/`, falling back to `~/.local/share/worktask/`.
 
 ## `editor`
 
-Command used by `worktask edit`. The value is run as a shell-style invocation with the resolved task path appended.
+Command used by `btw edit`. The value is run as a shell-style invocation with the resolved task path appended.
 
 Resolution order:
 
@@ -43,15 +43,15 @@ The first value that is set wins. `vi` is the final fallback.
 
 ## `research_model`
 
-Claude model id used by the headless research agent (`worktask research`).
+Claude model id used by the headless research agent (`btw research`).
 
 When unset, the runner picks its built-in default, currently `claude-sonnet-4-6`. Sonnet is the right default for retrieval+summarization across MCP tools — the interactive default (often Opus) would burn the usage limit on every batch sweep without a meaningful quality gain here.
 
-The `--model` flag on `worktask research` overrides this key for a single invocation.
+The `--model` flag on `btw research` overrides this key for a single invocation.
 
 ## `research_prompt_path`
 
-Path to a custom research prompt template. When unset, `worktask` ships an embedded default that is used as-is.
+Path to a custom research prompt template. When unset, `btw` ships an embedded default that is used as-is.
 
 The default is `<config_dir>/research-prompt.md` — i.e. a sibling of `config.toml`. Drop a file at that path (or anywhere `research_prompt_path` points) to override the embedded prompt without recompiling the binary.
 
@@ -74,7 +74,7 @@ When the key is absent, the agent runs against only the vanilla baseline.
 
 ### Threat model
 
-The research agent is spawned by `worktask` with `--permission-mode=bypassPermissions`. It runs unattended. The `--allowed-tools` list is the security boundary: anything on it can be invoked without prompting; anything off it is denied.
+The research agent is spawned by `btw` with `--permission-mode=bypassPermissions`. It runs unattended. The `--allowed-tools` list is the security boundary: anything on it can be invoked without prompting; anything off it is denied.
 
 That makes the contents of `research_extra_tools` security-meaningful. Two rules follow:
 
@@ -83,7 +83,7 @@ That makes the contents of `research_extra_tools` security-meaningful. Two rules
 
 ### Validation
 
-`worktask` rejects entries that would let the unattended agent write to disk or run arbitrary shell commands at config load. The error names the offending entry, its index in the list, and the path of the `config.toml` it came from, so you can locate and fix it in seconds.
+`btw` rejects entries that would let the unattended agent write to disk or run arbitrary shell commands at config load. The error names the offending entry, its index in the list, and the path of the `config.toml` it came from, so you can locate and fix it in seconds.
 
 Rejected entries:
 
@@ -200,8 +200,8 @@ research_extra_tools = [
 
 `gh api` is intentionally not on this list. It can issue arbitrary HTTP methods (`-X POST/PATCH/DELETE`, or `-f field=value` which auto-switches to POST), so the read/write boundary collapses to the `gh` auth token's scopes rather than the argv pattern.
 
-### Migrating from older `worktask`
+### Migrating from older `btw`
 
-Earlier versions of `worktask` shipped a personal allowlist hard-coded into the binary — Atlassian, Slack, Datadog, and `gh` MCP tool names were all in-source. That is no longer the case: the shipped binary's allowlist is `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`, and nothing else.
+Earlier versions of `btw` shipped a personal allowlist hard-coded into the binary — Atlassian, Slack, Datadog, and `gh` MCP tool names were all in-source. That is no longer the case: the shipped binary's allowlist is `Read`, `Glob`, `Grep`, `WebSearch`, `WebFetch`, and nothing else.
 
 If you were relying on the old in-source allowlist, add a `research_extra_tools` block to your `config.toml` per machine. The starter snippets above are drop-in equivalents to the previously-bundled lists.

--- a/docs/src/content/docs/design.md
+++ b/docs/src/content/docs/design.md
@@ -1,9 +1,9 @@
 ---
 title: Design notes
-description: Why worktask is shaped the way it is — out-of-scope items, internal package layout, and the migration tool.
+description: Why bytheway is shaped the way it is — out-of-scope items, internal package layout, and the migration tool.
 ---
 
-`worktask` is shaped around two readers: an LLM agent calling a thin slash command, and a human at a terminal. The agent gets stable JSON output with an explicit `error` discriminator so it can branch without parsing prose. The human gets one task per markdown file so `cat`, `grep`, `rg`, and `vim` work directly against the data directory without going through the binary. Most decisions below fall out of one of those two readers.
+`btw` is shaped around two readers: an LLM agent calling a thin slash command, and a human at a terminal. The agent gets stable JSON output with an explicit `error` discriminator so it can branch without parsing prose. The human gets one task per markdown file so `cat`, `grep`, `rg`, and `vim` work directly against the data directory without going through the binary. Most decisions below fall out of one of those two readers.
 
 ## Out of scope
 

--- a/docs/src/content/docs/examples/btw-slash-command.md
+++ b/docs/src/content/docs/examples/btw-slash-command.md
@@ -1,10 +1,10 @@
 ---
 title: Reference slash command
-description: Manage tasks via the worktask CLI
+description: Manage tasks via the bytheway CLI
 argument-hint: <add|list|show|close|reopen|update|append|tag|edit|research> [args...]
 ---
 
-Manage tasks via the `worktask` CLI. Task state lives in per-task markdown files under the configured XDG data directory; this command never reads, parses, or rewrites `WORKING.md` or any task file directly. The CLI owns ID generation, slug generation, match resolution, and formatting.
+Manage tasks via the `btw` CLI. Task state lives in per-task markdown files under the configured XDG data directory; this command never reads, parses, or rewrites `WORKING.md` or any task file directly. The CLI owns ID generation, slug generation, match resolution, and formatting.
 
 ## Dispatch
 
@@ -12,17 +12,17 @@ Parse `$ARGUMENTS` as `<subcommand> [args...]`. Shell out with `--format=json`:
 
 | Subcommand | Shell |
 |---|---|
-| `add <description>` | `worktask --format=json add "<description>"` |
-| `list` (also `--all`, `--closed`, `--limit N`, `--tag TAG`) | `worktask --format=json list [flags]` |
-| `show <frag>` | `worktask --format=json show "<frag>"` |
-| `close <frag>` | `worktask --format=json close "<frag>"` |
-| `reopen <frag>` | `worktask --format=json reopen "<frag>"` |
-| `update <frag> <new description>` | `worktask --format=json update "<frag>" "<new description>"` |
-| `append <frag> <text>` | `worktask --format=json append "<frag>" "<text>"` |
-| `tag add <frag> <tag>` | `worktask tag add "<frag>" "<tag>"` |
-| `tag rm <frag> <tag>` | `worktask tag rm "<frag>" "<tag>"` |
-| `tag ls` (also `--all`, `--closed`) | `worktask --format=json tag ls [flags]` |
-| `edit <frag>` | see below — do NOT shell out to `worktask edit` |
+| `add <description>` | `btw --format=json add "<description>"` |
+| `list` (also `--all`, `--closed`, `--limit N`, `--tag TAG`) | `btw --format=json list [flags]` |
+| `show <frag>` | `btw --format=json show "<frag>"` |
+| `close <frag>` | `btw --format=json close "<frag>"` |
+| `reopen <frag>` | `btw --format=json reopen "<frag>"` |
+| `update <frag> <new description>` | `btw --format=json update "<frag>" "<new description>"` |
+| `append <frag> <text>` | `btw --format=json append "<frag>" "<text>"` |
+| `tag add <frag> <tag>` | `btw tag add "<frag>" "<tag>"` |
+| `tag rm <frag> <tag>` | `btw tag rm "<frag>" "<tag>"` |
+| `tag ls` (also `--all`, `--closed`) | `btw --format=json tag ls [flags]` |
+| `edit <frag>` | see below — do NOT shell out to `btw edit` |
 | `research [<frag>]` | see "research" below — invokes a background bash, returns an ack, reports back when done |
 
 Quote each argument as a single token. `<frag>` may be an ID, ID prefix, or description fragment; the CLI resolves it.
@@ -44,19 +44,19 @@ When the CLI exits non-zero, parse stdout as JSON and branch on the `error` fiel
 
 ## `edit <frag>`
 
-`worktask edit` launches `$EDITOR` via `syscall.Exec`, which is not usable from an agent shell. Instead:
+`btw edit` launches `$EDITOR` via `syscall.Exec`, which is not usable from an agent shell. Instead:
 
-1. Run `worktask --format=json show "<frag>"` to validate the fragment.
+1. Run `btw --format=json show "<frag>"` to validate the fragment.
 2. If ambiguous or no_match, handle per the rules above.
-3. On a single match, tell the user: "Run `worktask edit <id>` from your shell to open it in your editor."
+3. On a single match, tell the user: "Run `btw edit <id>` from your shell to open it in your editor."
 
 ## `research [<frag>]`
 
 `research` spawns one or more headless `claude -p` agents that perform read-only research and write findings back to the task body. It can take minutes per task. Run it as a background bash so the parent session stays responsive.
 
 1. Invoke via the `Bash` tool with `run_in_background=true`:
-   - Single task: `worktask research "<frag>"`
-   - Sweep all open tasks (skip already-researched): `worktask research`
+   - Single task: `btw research "<frag>"`
+   - Sweep all open tasks (skip already-researched): `btw research`
    - Pass through `--all`, `--stale=<dur>`, `--tag=<tag>`, `--concurrency=N`, `--timeout=<dur>` flags if the user asked for them. `--tag` is batch-mode-only and composes as an additional AND with `--stale`/`--all`.
 2. Reply to the user with an immediate ack (e.g. "queued research on `<frag>`, I'll report when it lands") and stop. Do NOT block, poll, or sleep.
 3. The harness will notify you when the background bash exits. At that point read `BashOutput` for the run.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -3,7 +3,7 @@ title: Capture and investigate fast inbounds
 description: A Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and hand them off as entrypoints for agentic work in Claude Code.
 ---
 
-Worktask is a Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and turn them into entrypoints for agentic work in Claude Code. The funnel runs capture → soak → investigate → hand off; worktask owns capture and investigation, while shaping and handoff are left to downstream agents.
+Bytheway is a Go CLI to capture and investigate fast inbounds — Slack threads, hallway asks, leadership questions — and turn them into entrypoints for agentic work in Claude Code. The funnel runs capture → soak → investigate → hand off; bytheway owns capture and investigation, while shaping and handoff are left to downstream agents.
 
 The CLI is the agent-first surface: match resolution, ID generation, slug generation, and formatting all live in the binary so the agent never has to read or rewrite task files itself. Tasks are plain markdown — `cat`, `grep`, `rg`, and `vim` work directly against the data directory without going through the binary.
 
@@ -12,18 +12,18 @@ The CLI is the agent-first surface: match resolution, ID generation, slug genera
 Pre-built binary (no Go toolchain required):
 
 ```
-curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
-Installs the latest release to `$HOME/.local/bin/worktask`. Override the destination with `INSTALL_DIR=/usr/local/bin` or pin the release with `VERSION=0.2.0`. Full reference and verification details live on the [Install](./install.md) page.
+Installs the latest release to `$HOME/.local/bin/bytheway`. Override the destination with `INSTALL_DIR=/usr/local/bin` or pin the release with `VERSION=0.2.0`. Full reference and verification details live on the [Install](./install.md) page.
 
 From source (requires Go):
 
 ```
-go install github.com/jvcorredor/worktask@latest
+go install github.com/jvcorredor/bytheway@latest
 ```
 
-The binary lands in `$GOBIN` as `worktask`. Alias to `wt` if you want a shorter handle.
+The binary lands in `$GOBIN` as `btw`. Alias to `wt` if you want a shorter handle.
 
 ## Where to go next
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -1,17 +1,17 @@
 ---
 title: Install
-description: Install worktask from a pre-built binary or from source, with environment-variable overrides, $PATH setup, and checksum verification.
+description: Install bytheway from a pre-built binary or from source, with environment-variable overrides, $PATH setup, and checksum verification.
 ---
 
-worktask supports two install methods: a pre-built binary served from this docs site (no Go toolchain required), and `go install` from source.
+bytheway supports two install methods: a pre-built binary served from this docs site (no Go toolchain required), and `go install` from source.
 
 ## Pre-built binary
 
 ```
-curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
-The script downloads the platform-appropriate tarball and `checksums.txt` from the matching [GitHub Release](https://github.com/jvcorredor/worktask/releases), verifies the SHA256 of the tarball against the manifest, and extracts the `worktask` binary into the install directory. It does not edit any shell rc files.
+The script downloads the platform-appropriate tarball and `checksums.txt` from the matching [GitHub Release](https://github.com/jvcorredor/bytheway/releases), verifies the SHA256 of the tarball against the manifest, and extracts the `btw` binary into the install directory. It does not edit any shell rc files.
 
 ### Environment-variable overrides
 
@@ -21,8 +21,8 @@ The script downloads the platform-appropriate tarball and `checksums.txt` from t
 | `VERSION`     | latest GitHub release    | Pin to a specific release tag, e.g. `VERSION=0.2.0` (leading `v` optional).  |
 
 ```
-INSTALL_DIR=/usr/local/bin curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sudo sh
-VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+INSTALL_DIR=/usr/local/bin curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sudo sh
+VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
 ### Supported platforms
@@ -39,20 +39,20 @@ The script downloads `checksums.txt` from the same release and compares the SHA2
 
 ### Re-running the script
 
-If a `worktask` binary already lives at the destination, the script reads its version with `worktask version` and prints `Upgrading worktask from X to Y` when the resolved version differs.
+If a `btw` binary already lives at the destination, the script reads its version with `btw version` and prints `Upgrading bytheway from X to Y` when the resolved version differs.
 
 ### macOS quarantine note
 
 Tarballs downloaded through a browser get the `com.apple.quarantine` extended attribute, which makes Gatekeeper block the binary on first run. The install script downloads via `curl` and is unaffected. If you fetched the tarball manually instead, clear the attribute once before running:
 
 ```
-xattr -dr com.apple.quarantine ./worktask
+xattr -dr com.apple.quarantine ./bytheway
 ```
 
 ## From source (`go install`)
 
 ```
-go install github.com/jvcorredor/worktask@latest
+go install github.com/jvcorredor/bytheway@latest
 ```
 
-Requires a Go toolchain. The binary lands in `$GOBIN` (or `$GOPATH/bin`) as `worktask`. Pin a specific version with `@v0.2.0`. Module-mode `go install` does the same SHA verification as any other Go module download.
+Requires a Go toolchain. The binary lands in `$GOBIN` (or `$GOPATH/bin`) as `btw`. Pin a specific version with `@v0.2.0`. Module-mode `go install` does the same SHA verification as any other Go module download.

--- a/docs/src/content/docs/releases.md
+++ b/docs/src/content/docs/releases.md
@@ -1,9 +1,9 @@
 ---
 title: Releases
-description: How worktask versions and ships releases — Conventional Commits, pre-1.0 policy, and where to find the artifacts.
+description: How btw versions and ships releases — Conventional Commits, pre-1.0 policy, and where to find the artifacts.
 ---
 
-Release notes, source archives, and platform-specific tarballs for every version live on the [GitHub Releases page](https://github.com/jvcorredor/worktask/releases). The latest release is also what `curl ... | sh` installs by default; see [Install](./install.md).
+Release notes, source archives, and platform-specific tarballs for every version live on the [GitHub Releases page](https://github.com/jvcorredor/bytheway/releases). The latest release is also what `curl ... | sh` installs by default; see [Install](./install.md).
 
 ## Conventional Commits
 
@@ -29,11 +29,11 @@ This keeps the pre-1.0 surface free to evolve without prematurely committing to 
 `curl ... | sh` installs the latest release. To pin:
 
 ```
-VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/worktask/install.sh | sh
+VERSION=0.2.0 curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
 Or with `go install`:
 
 ```
-go install github.com/jvcorredor/worktask@v0.2.0
+go install github.com/jvcorredor/bytheway@v0.2.0
 ```

--- a/docs/src/content/docs/storage.md
+++ b/docs/src/content/docs/storage.md
@@ -1,9 +1,9 @@
 ---
 title: File & storage format
-description: How worktask lays out tasks on disk and the on-disk shape of each task file.
+description: How bytheway lays out tasks on disk and the on-disk shape of each task file.
 ---
 
-`worktask` keeps each task as its own markdown file. Status is encoded by which subdirectory the file lives in: `open/` or `closed/`. The data directory is plain enough that `cat`, `grep`, `rg`, and `vim` work directly without going through the binary.
+`btw` keeps each task as its own markdown file. Status is encoded by which subdirectory the file lives in: `open/` or `closed/`. The data directory is plain enough that `cat`, `grep`, `rg`, and `vim` work directly without going through the binary.
 
 ## Data directory
 

--- a/docs/yarn.lock
+++ b/docs/yarn.lock
@@ -1443,6 +1443,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"bytheway-docs@workspace:.":
+  version: 0.0.0-use.local
+  resolution: "bytheway-docs@workspace:."
+  dependencies:
+    "@astrojs/starlight": "npm:^0.38.4"
+    astro: "npm:^6.2.1"
+  languageName: unknown
+  linkType: soft
+
 "ccount@npm:^2.0.0":
   version: 2.0.1
   resolution: "ccount@npm:2.0.1"
@@ -4732,15 +4741,6 @@ __metadata:
   checksum: 10c0/7e710e54ea36d2d6183bee2f9caa27a3b47b9baf8dee55a199b736fcf85eab3b9df7556fca3d02b50af7f3dfba5ea3a45644189836df06267df457e354da66d5
   languageName: node
   linkType: hard
-
-"worktask-docs@workspace:.":
-  version: 0.0.0-use.local
-  resolution: "worktask-docs@workspace:."
-  dependencies:
-    "@astrojs/starlight": "npm:^0.38.4"
-    astro: "npm:^6.2.1"
-  languageName: unknown
-  linkType: soft
 
 "xxhash-wasm@npm:^1.1.0":
   version: 1.1.0

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/jvcorredor/worktask
+module github.com/jvcorredor/bytheway
 
 go 1.26.2
 

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,11 +1,11 @@
-// Package config loads and validates the user's worktask configuration.
+// Package config loads and validates the user's btw configuration.
 //
 // The configuration is read from a single TOML file. The path is
 // $XDG_CONFIG_HOME/worktask/config.toml when XDG_CONFIG_HOME is set, and
 // $HOME/.config/worktask/config.toml otherwise. A missing file is not an
 // error; defaults fill in. See the user-visible config keys and their
 // meanings on the docs site at
-// <https://jvcorredor.github.io/worktask/configuration/>.
+// <https://jvcorredor.github.io/bytheway/configuration/>.
 //
 // [Load] is the only entry point for callers; values that escape this
 // package have already passed [ValidateExtraTools] and are safe to feed
@@ -77,7 +77,7 @@ func Load() (Config, error) {
 	return cfg, nil
 }
 
-// ResolveEditor returns the editor command worktask should launch for
+// ResolveEditor returns the editor command btw should launch for
 // interactive edits. The configured Editor wins; otherwise the EDITOR
 // environment variable is used; otherwise the function falls back to vi.
 func (c Config) ResolveEditor() string {

--- a/internal/render/human.go
+++ b/internal/render/human.go
@@ -8,9 +8,9 @@ import (
 	"github.com/charmbracelet/lipgloss"
 	"github.com/charmbracelet/lipgloss/table"
 
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
-	"github.com/jvcorredor/worktask/internal/tty"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
+	"github.com/jvcorredor/bytheway/internal/tty"
 )
 
 const (

--- a/internal/render/render.go
+++ b/internal/render/render.go
@@ -31,7 +31,7 @@
 // preserving the pipe-mode round-trip contract.
 //
 // JSON research-run schema (stable): per-task summary line emitted on stdout
-// when `worktask research <hash>` completes.
+// when `btw research <hash>` completes.
 //
 //	{
 //	  "id":          string,  // 8-char lowercase hex
@@ -51,8 +51,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 type jsonTask struct {
@@ -138,7 +138,7 @@ type jsonResearchRun struct {
 }
 
 // JSONResearchRun renders the per-task summary line emitted on stdout
-// when `worktask research <hash>` completes. The output schema is
+// when `btw research <hash>` completes. The output schema is
 // described in the package documentation.
 func JSONResearchRun(r ResearchRun) ([]byte, error) {
 	return marshalIndent(jsonResearchRun(r))

--- a/internal/render/render_test.go
+++ b/internal/render/render_test.go
@@ -9,8 +9,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestJSONList_matchesSnapshot(t *testing.T) {

--- a/internal/render/zzgen_test.go
+++ b/internal/render/zzgen_test.go
@@ -6,14 +6,14 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
-// TestZGenerateGoldenFiles is a one-shot helper enabled with WORKTASK_GOLDEN=1
+// TestZGenerateGoldenFiles is a one-shot helper enabled with BTW_GOLDEN=1
 // to (re)generate golden testdata files for new render shapes.
 func TestZGenerateGoldenFiles(t *testing.T) {
-	if os.Getenv("WORKTASK_GOLDEN") != "1" {
-		t.Skip("set WORKTASK_GOLDEN=1 to regenerate golden files")
+	if os.Getenv("BTW_GOLDEN") != "1" {
+		t.Skip("set BTW_GOLDEN=1 to regenerate golden files")
 	}
 	emit := func(name string, fn func() ([]byte, error)) {
 		t.Helper()

--- a/internal/research/log/log.go
+++ b/internal/research/log/log.go
@@ -1,5 +1,5 @@
 // Package log computes filesystem paths for research run log files
-// under the worktask tasks directory.
+// under the btw tasks directory.
 package log
 
 import (

--- a/internal/research/pool/pool.go
+++ b/internal/research/pool/pool.go
@@ -13,8 +13,8 @@ import (
 	"sync"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // Item is one unit of pool work. All fields are populated by the caller

--- a/internal/research/pool/pool_test.go
+++ b/internal/research/pool/pool_test.go
@@ -7,8 +7,8 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestRun_emptyInputClosesEventsAndReturnsZeroSummary(t *testing.T) {

--- a/internal/research/prompt/prompt.go
+++ b/internal/research/prompt/prompt.go
@@ -11,7 +11,7 @@ import (
 	"os"
 	"text/template"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 //go:embed prompt.md

--- a/internal/research/prompt/prompt_test.go
+++ b/internal/research/prompt/prompt_test.go
@@ -7,7 +7,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestLoad_emptyOverrideReturnsEmbeddedDefault(t *testing.T) {
@@ -57,7 +57,7 @@ func TestEmbeddedDefault_namesNoInstallSpecificMCPsOrGhPatterns(t *testing.T) {
 	// `mcp__context7__*`, or `Bash(gh ...)` identifiers in the embedded
 	// prompt would push the agent toward tools a fresh-install user does
 	// not have. Claude Code injects the actually-available tools into its
-	// system prompt, so the agent discovers them without `worktask`
+	// system prompt, so the agent discovers them without `btw`
 	// naming them.
 	got, err := Load("")
 	if err != nil {

--- a/internal/research/research.go
+++ b/internal/research/research.go
@@ -20,13 +20,13 @@ import (
 	"sync"
 	"time"
 
-	researchlog "github.com/jvcorredor/worktask/internal/research/log"
-	"github.com/jvcorredor/worktask/internal/research/pool"
-	"github.com/jvcorredor/worktask/internal/research/prompt"
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/research/writeback"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
+	researchlog "github.com/jvcorredor/bytheway/internal/research/log"
+	"github.com/jvcorredor/bytheway/internal/research/pool"
+	"github.com/jvcorredor/bytheway/internal/research/prompt"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/research/writeback"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 // RunFunc is the runner-shaped seam the [Coordinator] depends on.
@@ -49,7 +49,7 @@ func DefaultRun(ctx context.Context, in runner.RunInput) (runner.Result, error) 
 // ExtraTools have already absorbed flag overrides, and the prompt
 // template is loaded from disk and passed to [New] separately.
 type Config struct {
-	// TasksDir is the absolute path to the worktask tasks directory.
+	// TasksDir is the absolute path to the btw tasks directory.
 	// Used by [researchlog.Path] to build per-task log filenames.
 	TasksDir string
 	// WorkingLogPath is the absolute path of the worklog file the

--- a/internal/research/research_test.go
+++ b/internal/research/research_test.go
@@ -9,9 +9,9 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 const fixedTemplate = "Research the following task:\n\n{{.Body}}"

--- a/internal/research/runner/runner.go
+++ b/internal/research/runner/runner.go
@@ -53,7 +53,7 @@ type Command struct {
 // install has — no MCPs, no Bash patterns. The shipped binary cannot assume
 // any particular MCP server is installed in the user's environment, so
 // install-specific tool wiring (Slack/Jira/Datadog MCPs, Bash(gh:*) patterns,
-// etc.) is config-owned: users opt in via worktask config, which a
+// etc.) is config-owned: users opt in via btw config, which a
 // follow-up slice will load with validation that rejects bare Bash and any
 // non-`mcp__*`/non-`Bash(...)` entry.
 //

--- a/internal/research/writeback/writeback.go
+++ b/internal/research/writeback/writeback.go
@@ -10,8 +10,8 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/research/runner"
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/research/runner"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 // Input is the side-effect payload for one research run.

--- a/internal/store/store.go
+++ b/internal/store/store.go
@@ -22,10 +22,10 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/id"
-	"github.com/jvcorredor/worktask/internal/slug"
-	"github.com/jvcorredor/worktask/internal/tag"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/id"
+	"github.com/jvcorredor/bytheway/internal/slug"
+	"github.com/jvcorredor/bytheway/internal/tag"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 const slugMaxLen = 40

--- a/internal/store/store_test.go
+++ b/internal/store/store_test.go
@@ -9,7 +9,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 func TestAdd_writesFileToOpenDir(t *testing.T) {

--- a/internal/task/task.go
+++ b/internal/task/task.go
@@ -9,7 +9,7 @@
 // preserved verbatim. The user-visible specification of this format,
 // including which fields are stable and how they interact with the CLI,
 // lives on the docs site at
-// <https://jvcorredor.github.io/worktask/storage/>; this package
+// <https://jvcorredor.github.io/bytheway/storage/>; this package
 // implements that contract and does not duplicate it.
 //
 // [Encode] and [Decode] are the only entry points; the rest of the codec
@@ -22,7 +22,7 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/tag"
+	"github.com/jvcorredor/bytheway/internal/tag"
 )
 
 // Task is the in-memory representation of one task file. The zero value

--- a/internal/version/version.go
+++ b/internal/version/version.go
@@ -1,4 +1,4 @@
-// Package version reports the worktask binary's build identity.
+// Package version reports the btw binary's build identity.
 //
 // Resolution order, hidden behind [Get]:
 //
@@ -17,7 +17,7 @@ import "runtime/debug"
 
 // Version, Commit, and Date are the ldflags landing zone inside this
 // package. They are intentionally exported so a release build can wire
-// them via `-ldflags="-X github.com/jvcorredor/worktask/internal/version.Version=v1.2.3 ..."`.
+// them via `-ldflags="-X github.com/jvcorredor/bytheway/internal/version.Version=v1.2.3 ..."`.
 // Unset, [Get] falls back to module-proxy metadata or sentinel defaults.
 var (
 	Version string
@@ -35,7 +35,7 @@ var readBuildInfo = debug.ReadBuildInfo
 // Source records which resolution branch produced the values:
 // "ldflags", "buildinfo", or "default". Callers should treat the field
 // as part of the contract rather than a debugging aid; the JSON
-// rendering of `worktask version --format=json` exposes it.
+// rendering of `btw version --format=json` exposes it.
 type Info struct {
 	Version string
 	Commit  string

--- a/justfile
+++ b/justfile
@@ -2,9 +2,9 @@
 default:
     @just --list
 
-# Compile the worktask CLI to ./bin/worktask
+# Compile the btw CLI to ./bin/btw
 build:
-    go build -o ./bin/worktask .
+    go build -o ./bin/btw .
 
 # Run the Go test suite
 test:
@@ -14,7 +14,7 @@ test:
 test-install:
     sh tests/install/run.sh
 
-# Run the post-release smoke-test assertion script's harness (POSIX shell, mocked worktask)
+# Run the post-release smoke-test assertion script's harness (POSIX shell, mocked btw)
 test-smoke-version:
     sh tests/smoke-test-version/run.sh
 
@@ -44,7 +44,7 @@ docs-build:
 
 # Placeholder for the lint gate; wired up in #10
 lint:
-    @echo "lint is not yet implemented; see https://github.com/jvcorredor/worktask/issues/10" >&2; exit 1
+    @echo "lint is not yet implemented; see https://github.com/jvcorredor/bytheway/issues/10" >&2; exit 1
 
 # Run the full local CI gate (fmt-check, vet, test, test-install, test-smoke-version) in workflow order
 ci: fmt-check vet test test-install test-smoke-version

--- a/main.go
+++ b/main.go
@@ -1,6 +1,6 @@
 package main
 
-import "github.com/jvcorredor/worktask/cmd"
+import "github.com/jvcorredor/bytheway/cmd"
 
 func main() {
 	cmd.Execute()

--- a/migrate/migrate.go
+++ b/migrate/migrate.go
@@ -1,4 +1,4 @@
-// Command worktask-migrate is the one-shot migration tool that promotes
+// Command btw-migrate is the one-shot migration tool that promotes
 // the legacy WORKING.md working log into the per-task file layout under
 // the configured tasks directory. The transformation contract is
 // documented on [Run].
@@ -11,9 +11,9 @@ import (
 	"strings"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/config"
-	"github.com/jvcorredor/worktask/internal/store"
-	"github.com/jvcorredor/worktask/internal/task"
+	"github.com/jvcorredor/bytheway/internal/config"
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
 )
 
 const tsLayout = "2006-01-02 15:04"
@@ -123,7 +123,7 @@ func parseTaskLine(line string) (task.Task, string, bool) {
 
 func main() {
 	if len(os.Args) != 2 {
-		fmt.Fprintln(os.Stderr, "usage: worktask-migrate <WORKING.md>")
+		fmt.Fprintln(os.Stderr, "usage: btw-migrate <WORKING.md>")
 		os.Exit(2)
 	}
 	cfg, err := config.Load()

--- a/migrate/migrate_test.go
+++ b/migrate/migrate_test.go
@@ -6,7 +6,7 @@ import (
 	"testing"
 	"time"
 
-	"github.com/jvcorredor/worktask/internal/store"
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 func TestRun_TracerBullet(t *testing.T) {

--- a/tests/install/run.sh
+++ b/tests/install/run.sh
@@ -8,9 +8,9 @@
 #                          (the curl shim resolves URLs to files under here)
 #
 # The shim maps:
-#   https://api.github.com/repos/jvcorredor/worktask/releases/latest
+#   https://api.github.com/repos/jvcorredor/bytheway/releases/latest
 #       -> $fixtures/latest.json
-#   https://github.com/jvcorredor/worktask/releases/download/<rest>
+#   https://github.com/jvcorredor/bytheway/releases/download/<rest>
 #       -> $fixtures/<rest>
 #
 # Cases assemble the fixture tree they need, invoke install.sh under HOME=$home_dir
@@ -46,7 +46,7 @@ cleanup_sandbox() {
 
 # Build a fake release tarball + checksums.txt under $fixtures/<tag>/.
 # Args: tag (e.g. v0.2.0), os (linux|darwin), arch (amd64|arm64), [version_for_binary]
-# The fake binary is a shell script that prints "worktask <version>" on `version`.
+# The fake binary is a shell script that prints "btw <version>" on `version`.
 build_fixture_release() {
     tag="$1"; os="$2"; arch="$3"
     version="${4:-${tag#v}}"
@@ -54,16 +54,16 @@ build_fixture_release() {
     mkdir -p "$rel_dir"
     build_dir="$sandbox/build.$$.$tag.$os.$arch"
     mkdir -p "$build_dir"
-    cat >"$build_dir/worktask" <<EOF
+    cat >"$build_dir/btw" <<EOF
 #!/bin/sh
 case "\$1" in
-    version|--version|-v) echo "worktask $version" ;;
-    *) echo "worktask $version" ;;
+    version|--version|-v) echo "btw $version" ;;
+    *) echo "btw $version" ;;
 esac
 EOF
-    chmod +x "$build_dir/worktask"
-    tarball="worktask_${version}_${os}_${arch}.tar.gz"
-    tar -czf "$rel_dir/$tarball" -C "$build_dir" worktask
+    chmod +x "$build_dir/btw"
+    tarball="bytheway_${version}_${os}_${arch}.tar.gz"
+    tar -czf "$rel_dir/$tarball" -C "$build_dir" btw
     # Append to checksums.txt (one release may have multiple platforms).
     (
         cd "$rel_dir"
@@ -99,10 +99,10 @@ done
 [ -n "${WT_CURL_LOG:-}" ] && printf '%s\n' "$url" >>"$WT_CURL_LOG"
 src=
 case "$url" in
-    https://api.github.com/repos/jvcorredor/worktask/releases/latest)
+    https://api.github.com/repos/jvcorredor/bytheway/releases/latest)
         src="$WT_FIXTURES/latest.json" ;;
-    https://github.com/jvcorredor/worktask/releases/download/*)
-        rest="${url#https://github.com/jvcorredor/worktask/releases/download/}"
+    https://github.com/jvcorredor/bytheway/releases/download/*)
+        rest="${url#https://github.com/jvcorredor/bytheway/releases/download/}"
         src="$WT_FIXTURES/$rest" ;;
     *)
         echo "curl-shim: unhandled url $url" >&2; exit 22 ;;
@@ -159,9 +159,9 @@ case_tracer_bullet_default_install() {
     build_fixture_release v0.2.0 linux amd64
     fixture_latest_tag v0.2.0
     run_install
-    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
-    out="$("$home_dir/.local/bin/worktask" version)"
-    [ "$out" = "worktask 0.2.0" ] || { echo "version mismatch: $out"; return 1; }
+    [ -x "$home_dir/.local/bin/btw" ] || { echo "binary not installed"; return 1; }
+    out="$("$home_dir/.local/bin/btw" version)"
+    [ "$out" = "btw 0.2.0" ] || { echo "version mismatch: $out"; return 1; }
 }
 
 case_install_dir_override() {
@@ -171,8 +171,8 @@ case_install_dir_override() {
     fixture_latest_tag v0.2.0
     custom="$sandbox/custom/bin"
     run_install INSTALL_DIR="$custom"
-    [ -x "$custom/worktask" ] || { echo "binary not in custom dir"; return 1; }
-    [ ! -e "$home_dir/.local/bin/worktask" ] || { echo "binary leaked into default dir"; return 1; }
+    [ -x "$custom/btw" ] || { echo "binary not in custom dir"; return 1; }
+    [ ! -e "$home_dir/.local/bin/btw" ] || { echo "binary leaked into default dir"; return 1; }
 }
 
 case_version_pin_skips_latest_lookup() {
@@ -181,8 +181,8 @@ case_version_pin_skips_latest_lookup() {
     build_fixture_release v0.1.0 linux amd64
     # Intentionally no latest.json — VERSION must skip the /latest call.
     run_install VERSION=0.1.0
-    out="$("$home_dir/.local/bin/worktask" version)"
-    [ "$out" = "worktask 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
+    out="$("$home_dir/.local/bin/btw" version)"
+    [ "$out" = "btw 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
 }
 
 case_version_pin_accepts_v_prefix() {
@@ -190,8 +190,8 @@ case_version_pin_accepts_v_prefix() {
     install_uname_shim Linux x86_64
     build_fixture_release v0.1.0 linux amd64
     run_install VERSION=v0.1.0
-    out="$("$home_dir/.local/bin/worktask" version)"
-    [ "$out" = "worktask 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
+    out="$("$home_dir/.local/bin/btw" version)"
+    [ "$out" = "btw 0.1.0" ] || { echo "wrong version installed: $out"; return 1; }
 }
 
 case_default_version_calls_latest_api() {
@@ -200,7 +200,7 @@ case_default_version_calls_latest_api() {
     build_fixture_release v0.2.0 linux amd64
     fixture_latest_tag v0.2.0
     run_install
-    grep -qx 'https://api.github.com/repos/jvcorredor/worktask/releases/latest' \
+    grep -qx 'https://api.github.com/repos/jvcorredor/bytheway/releases/latest' \
         "$sandbox/curl.log" \
         || { echo "expected /releases/latest in curl log:"; cat "$sandbox/curl.log"; return 1; }
 }
@@ -210,7 +210,7 @@ case_version_pin_does_not_call_latest_api() {
     install_uname_shim Linux x86_64
     build_fixture_release v0.1.0 linux amd64
     run_install VERSION=0.1.0
-    if grep -qx 'https://api.github.com/repos/jvcorredor/worktask/releases/latest' \
+    if grep -qx 'https://api.github.com/repos/jvcorredor/bytheway/releases/latest' \
         "$sandbox/curl.log"; then
         echo "VERSION pin should not call /releases/latest, but it did:"
         cat "$sandbox/curl.log"
@@ -224,12 +224,12 @@ case_checksum_mismatch_aborts() {
     build_fixture_release v0.2.0 linux amd64
     fixture_latest_tag v0.2.0
     # Corrupt the tarball after checksums.txt was written, so SHA won't match.
-    printf 'corrupted' >>"$fixtures/v0.2.0/worktask_0.2.0_linux_amd64.tar.gz"
+    printf 'corrupted' >>"$fixtures/v0.2.0/bytheway_0.2.0_linux_amd64.tar.gz"
     if run_install; then
         echo "install.sh should have failed on checksum mismatch"
         return 1
     fi
-    [ ! -e "$home_dir/.local/bin/worktask" ] \
+    [ ! -e "$home_dir/.local/bin/btw" ] \
         || { echo "binary was installed despite checksum mismatch"; return 1; }
 }
 
@@ -326,7 +326,7 @@ case_platform_linux_arm64() {
     build_fixture_release v0.2.0 linux arm64
     fixture_latest_tag v0.2.0
     run_install
-    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+    [ -x "$home_dir/.local/bin/btw" ] || { echo "binary not installed"; return 1; }
 }
 
 case_platform_darwin_amd64() {
@@ -335,7 +335,7 @@ case_platform_darwin_amd64() {
     build_fixture_release v0.2.0 darwin amd64
     fixture_latest_tag v0.2.0
     run_install
-    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+    [ -x "$home_dir/.local/bin/btw" ] || { echo "binary not installed"; return 1; }
 }
 
 case_platform_darwin_arm64() {
@@ -344,7 +344,7 @@ case_platform_darwin_arm64() {
     build_fixture_release v0.2.0 darwin arm64
     fixture_latest_tag v0.2.0
     run_install
-    [ -x "$home_dir/.local/bin/worktask" ] || { echo "binary not installed"; return 1; }
+    [ -x "$home_dir/.local/bin/btw" ] || { echo "binary not installed"; return 1; }
 }
 
 case_platform_unsupported_os_aborts() {

--- a/tests/smoke-test-version/run.sh
+++ b/tests/smoke-test-version/run.sh
@@ -1,6 +1,6 @@
 #!/bin/sh
 # Black-box test for smoke-test-version.sh. Runs the script with a fake
-# `worktask` binary on PATH and verifies exit codes and stderr for each
+# `btw` binary on PATH and verifies exit codes and stderr for each
 # behaviour the smoke-test job depends on.
 
 set -eu
@@ -24,29 +24,29 @@ assert() {
     fi
 }
 
-with_fake_worktask() {
+with_fake_btw() {
     reported_version="$1"
     workdir=$(mktemp -d "${TMPDIR:-/tmp}/smoke-test.XXXXXX")
-    cat >"$workdir/worktask" <<EOF
+    cat >"$workdir/btw" <<EOF
 #!/bin/sh
 cat <<JSON
 {"version":"$reported_version","commit":"abc","date":"2026-05-03","source":"ldflags"}
 JSON
 EOF
-    chmod +x "$workdir/worktask"
+    chmod +x "$workdir/btw"
     printf '%s\n' "$workdir"
 }
 
 # Case 1: matching version exits 0.
 start_case 'matching version exits 0'
-shim=$(with_fake_worktask 0.4.0)
+shim=$(with_fake_btw 0.4.0)
 PATH="$shim:$PATH" EXPECTED_VERSION=0.4.0 sh "$script" >/dev/null 2>&1
 assert "$?" 0
 rm -rf "$shim"
 
 # Case 2: mismatched version exits non-zero with both versions in stderr.
 start_case 'mismatched version exits non-zero'
-shim=$(with_fake_worktask 0.3.9)
+shim=$(with_fake_btw 0.3.9)
 err=$(PATH="$shim:$PATH" EXPECTED_VERSION=0.4.0 sh "$script" 2>&1 1>/dev/null) && rc=0 || rc=$?
 assert "$rc" 1
 case "$err" in
@@ -60,13 +60,13 @@ rm -rf "$shim"
 
 # Case 3: missing EXPECTED_VERSION env exits non-zero.
 start_case 'missing EXPECTED_VERSION exits non-zero'
-shim=$(with_fake_worktask 0.4.0)
+shim=$(with_fake_btw 0.4.0)
 PATH="$shim:$PATH" sh "$script" >/dev/null 2>&1 && rc=0 || rc=$?
 [ "$rc" -ne 0 ] && printf '  ok  %s\n' "$case_name" || { printf '  FAIL %s: exited 0\n' "$case_name" >&2; fail=1; }
 rm -rf "$shim"
 
-# Case 4: worktask not on PATH exits non-zero.
-start_case 'missing worktask binary exits non-zero'
+# Case 4: btw not on PATH exits non-zero.
+start_case 'missing btw binary exits non-zero'
 empty=$(mktemp -d "${TMPDIR:-/tmp}/empty.XXXXXX")
 PATH="$empty" EXPECTED_VERSION=0.4.0 sh "$script" >/dev/null 2>&1 && rc=0 || rc=$?
 [ "$rc" -ne 0 ] && printf '  ok  %s\n' "$case_name" || { printf '  FAIL %s: exited 0\n' "$case_name" >&2; fail=1; }


### PR DESCRIPTION
## Summary

- Module path → `github.com/jvcorredor/bytheway`. CLI binary → `btw`. Release tarball → `bytheway_<ver>_<os>_<arch>.tar.gz`. Docs site → `https://jvcorredor.github.io/bytheway/`.
- The slash-command reference is renamed to `docs/src/content/docs/examples/btw-slash-command.md`.
- All build/release/install infra (justfile, `.goreleaser.yaml`, `.github/workflows/release.yml`, `.github/scripts/smoke-test-version.sh`, `docs/public/install.sh`, `tests/install/run.sh`, `tests/smoke-test-version/run.sh`) renamed in lockstep.

## Intentionally allow-listed `worktask` references

The on-disk data/config directory basenames stay as `worktask`:
- `$XDG_DATA_HOME/worktask` and `~/.local/share/worktask`
- `$XDG_CONFIG_HOME/worktask` and `~/.config/worktask`

Renaming those would orphan every existing user's tasks. The dir-name migration is intentionally out of scope here. The leftover `worktask` matches in `git grep -i worktask` after this PR are confined to:
- `internal/config/config.go` and `internal/config/config_test.go` — the runtime defaults and tests for them.
- `docs/src/content/docs/storage.md` and `docs/src/content/docs/config.md` — documentation of those defaults.
- `cmd/*_test.go` — test mocks that mirror those defaults (`filepath.Join(tmp, "worktask", "open")` etc.).
- `internal/research/log/log_test.go` and `internal/research/runner/runner_test.go` — fixture paths under `/var/data/worktask`.

## Notes

- `BREAKING CHANGE`: installed binary is `btw`, not `worktask`. Reinstall via `curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh` or `go install github.com/jvcorredor/bytheway@latest`, then remove the old binary from `$PATH`.
- The internal env var `WORKTASK_GOLDEN` (golden-file regeneration) is renamed to `BTW_GOLDEN`.
- The `migrate` package's `worktask-migrate` references are renamed to `btw-migrate`. It is not built as a release artifact.
- #112 (the GitHub repo rename) is effectively complete: both `jvcorredor/worktask` and `jvcorredor/bytheway` now resolve to the renamed repo via GitHub's redirect.

## Test plan

- [x] `just ci` passes locally (fmt-check, vet, go test, install harness, smoke-test-version harness — all green)
- [x] `golangci-lint run` reports 0 issues
- [x] `yarn build` in `docs/` succeeds; `examples/btw-slash-command/` is in the build output
- [x] `git grep -i worktask` matches only the allow-listed entries above
- [ ] Tagged release builds via GoReleaser produce `btw` inside `bytheway_<ver>_<os>_<arch>.tar.gz` (verified post-merge)
- [ ] `curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh` installs `btw` (verified post-merge)
- [ ] Smoke-test job in `release.yml` passes against the next published release

Closes #113

🤖 Generated with [Claude Code](https://claude.com/claude-code)