### PR TITLE
fix(ci): point smoke-test install URL to /bytheway/

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,7 +69,7 @@ jobs:
 
       - name: Install btw via published install script
         run: |
-          curl -fsSL https://jvcorredor.github.io/btw/install.sh | sh
+          curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
           printf '%s/.local/bin\n' "$HOME" >>"$GITHUB_PATH"
 
       - name: Assert installed binary reports the released version

--- a/docs/public/install.sh
+++ b/docs/public/install.sh
@@ -1,7 +1,7 @@
 #!/bin/sh
 # btw installer — POSIX, no bashisms.
 #
-# Usage:  curl -fsSL https://jvcorredor.github.io/btw/install.sh | sh
+# Usage:  curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 #
 # Env vars:
 #   INSTALL_DIR   destination directory (default: $HOME/.local/bin)


### PR DESCRIPTION
## Summary

- The rename PR (#114) updated the docs site to publish at `https://jvcorredor.github.io/bytheway/`, but two stale references to `/btw/install.sh` slipped through.
- Post-release smoke test in `.github/workflows/release.yml` 404s on the install script — see the failed run on the rename merge: https://github.com/jvcorredor/bytheway/actions/runs/25296921298/job/74157240240.
- Also fixes the `Usage:` comment inside `docs/public/install.sh` so the user-facing one-liner is correct.

Closes: #115

## Test plan

- [x] `just test-install` (20/20 cases pass)
- [x] `curl -sI https://jvcorredor.github.io/bytheway/install.sh` returns 200 (the corrected URL is already live, so the next post-release smoke test will succeed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)