### PR TITLE
docs(install): correct binary names and document btw alias

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 go install github.com/jvcorredor/bytheway@latest
 ```
 
-The binary lands in `$HOME/.local/bin` (or `$GOBIN` for `go install`) as `btw`. See the [install reference](https://jvcorredor.github.io/bytheway/install/) for env-var overrides and `$PATH` setup.
+The shell installer lands `btw` in `$HOME/.local/bin`. `go install` lands `bytheway` in `$GOBIN` — alias it with `alias btw=bytheway` (bash/zsh) or `alias --save btw=bytheway` (fish). See the [install reference](https://jvcorredor.github.io/bytheway/install/) for env-var overrides, `$PATH` setup, and the alias rationale.
 
 ## Documentation
 

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -15,7 +15,7 @@ Pre-built binary (no Go toolchain required):
 curl -fsSL https://jvcorredor.github.io/bytheway/install.sh | sh
 ```
 
-Installs the latest release to `$HOME/.local/bin/bytheway`. Override the destination with `INSTALL_DIR=/usr/local/bin` or pin the release with `VERSION=0.2.0`. Full reference and verification details live on the [Install](./install.md) page.
+Installs the latest release to `$HOME/.local/bin/btw`. Override the destination with `INSTALL_DIR=/usr/local/bin` or pin the release with `VERSION=0.2.0`. Full reference and verification details live on the [Install](./install.md) page.
 
 From source (requires Go):
 
@@ -23,7 +23,7 @@ From source (requires Go):
 go install github.com/jvcorredor/bytheway@latest
 ```
 
-The binary lands in `$GOBIN` as `btw`. Alias to `wt` if you want a shorter handle.
+The binary lands in `$GOBIN` as `bytheway` (the shell installer above is the path that produces a `btw` executable directly). Alias `btw=bytheway` if you want the shorter handle — see the [Install](./install.md#from-source-go-install) page.
 
 ## Where to go next
 

--- a/docs/src/content/docs/install.md
+++ b/docs/src/content/docs/install.md
@@ -55,4 +55,16 @@ xattr -dr com.apple.quarantine ./bytheway
 go install github.com/jvcorredor/bytheway@latest
 ```
 
-Requires a Go toolchain. The binary lands in `$GOBIN` (or `$GOPATH/bin`) as `btw`. Pin a specific version with `@v0.2.0`. Module-mode `go install` does the same SHA verification as any other Go module download.
+Requires a Go toolchain. The binary lands in `$GOBIN` (or `$GOPATH/bin`) as `bytheway` — `go install` derives the executable name from the last element of the module path and offers no flag to override it. Pin a specific version with `@v0.2.0`. Module-mode `go install` does the same SHA verification as any other Go module download.
+
+If you want to invoke it as `btw`, add a shell alias:
+
+```
+# bash / zsh — in ~/.bashrc or ~/.zshrc
+alias btw=bytheway
+
+# fish — persists as ~/.config/fish/functions/btw.fish
+alias --save btw=bytheway
+```
+
+For a real `btw` executable on disk (no alias indirection), use the [pre-built binary](#pre-built-binary) install method instead — the release tarball ships the binary as `btw`.


### PR DESCRIPTION
## Summary

- The install docs claimed `go install github.com/jvcorredor/bytheway@latest` lands a binary named `btw`. It doesn't — `go install` derives the executable name from the last element of the module path, so it lands one named `bytheway`. There is no flag to override this. The claim is wrong in `README.md`, `docs/src/content/docs/install.md`, and `docs/src/content/docs/index.md`.
- The homepage went the other way and claimed the shell installer lands `$HOME/.local/bin/bytheway`. It actually lands `$HOME/.local/bin/btw` (the goreleaser tarball ships the binary as `btw` and `install.sh` extracts it under that name).
- Adds a shell-alias snippet (bash/zsh/fish) so `go install` users can keep invoking it as `btw`, and drops the stale `alias to wt` line that referenced the old `worktask` name.

## Test plan

- [ ] Render the docs site locally (`just docs-dev`) and confirm the Install page and homepage read correctly.
- [ ] Spot-check that the new `#from-source-go-install` anchor on the Install page resolves from the homepage link.

🤖 Generated with [Claude Code](https://claude.com/claude-code)