### PR TITLE
feat(cli): tab-complete task fragments from the store

### DIFF
--- a/cmd/append.go
+++ b/cmd/append.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var appendCmd = &cobra.Command{
-	Use:   "append <fragment> <text>",
-	Short: "Append text to the body of a task",
-	Args:  cobra.ExactArgs(2),
+	Use:               "append <fragment> <text>",
+	Short:             "Append text to the body of a task",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment, text := args[0], args[1]
 		s, err := newStore()

--- a/cmd/close.go
+++ b/cmd/close.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var closeCmd = &cobra.Command{
-	Use:   "close <fragment>",
-	Short: "Move a task from open to closed and stamp completed",
-	Args:  cobra.ExactArgs(1),
+	Use:               "close <fragment>",
+	Short:             "Move a task from open to closed and stamp completed",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeFragment(store.FilterOpen),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment := args[0]
 		s, err := newStore()

--- a/cmd/completion.go
+++ b/cmd/completion.go
@@ -1,0 +1,59 @@
+package cmd
+
+import (
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
+)
+
+// completeFragment returns a cobra ValidArgsFunction that lists task
+// ids from the store as completion candidates, with the task's first
+// body line attached as the description so fish (and zsh) can render
+// it next to the candidate in the completion menu. The filter argument
+// selects which subset of tasks is offered: store.FilterOpen for
+// `close`, store.FilterClosed for `reopen`, and store.FilterAll for
+// commands that accept either.
+//
+// Only the first positional argument receives task candidates;
+// subsequent arguments return no candidates and suppress filename
+// fallback so a stray <Tab> does not flood the user with file
+// completions in commands like `update <fragment> <text>`.
+//
+// Errors loading the store or listing tasks are swallowed: completion
+// silently returns no candidates rather than dumping a stack trace
+// into the user's shell.
+func completeFragment(filter store.Filter) func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+	return func(cmd *cobra.Command, args []string, toComplete string) ([]string, cobra.ShellCompDirective) {
+		if len(args) > 0 {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		s, err := newStore()
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		tasks, err := s.List(filter, 0, "")
+		if err != nil {
+			return nil, cobra.ShellCompDirectiveNoFileComp
+		}
+		out := make([]string, 0, len(tasks))
+		for _, t := range tasks {
+			desc := completionFirstLine(t.Body)
+			if desc == "" {
+				out = append(out, t.ID)
+				continue
+			}
+			out = append(out, t.ID+"\t"+desc)
+		}
+		return out, cobra.ShellCompDirectiveNoFileComp
+	}
+}
+
+func completionFirstLine(body string) string {
+	body = strings.TrimRight(body, "\n")
+	if i := strings.IndexByte(body, '\n'); i >= 0 {
+		return body[:i]
+	}
+	return body
+}

--- a/cmd/completion_test.go
+++ b/cmd/completion_test.go
@@ -1,0 +1,152 @@
+package cmd
+
+import (
+	"os"
+	"path/filepath"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
+	"github.com/jvcorredor/bytheway/internal/task"
+)
+
+// completionFixture seeds the standard temp tasks dir layout used by
+// the cobra command tests with two open and one closed task and returns
+// the closed task's id (the rest are deterministic literals).
+func completionFixture(t *testing.T) {
+	t.Helper()
+	tmp := t.TempDir()
+	t.Setenv("XDG_DATA_HOME", tmp)
+	t.Setenv("XDG_CONFIG_HOME", filepath.Join(tmp, "config"))
+
+	openDir := filepath.Join(tmp, "worktask", "open")
+	closedDir := filepath.Join(tmp, "worktask", "closed")
+	for _, d := range []string{openDir, closedDir} {
+		if err := os.MkdirAll(d, 0o755); err != nil {
+			t.Fatalf("mkdir %s: %v", d, err)
+		}
+	}
+
+	writeTaskFile(t, openDir, task.Task{
+		ID:      "open0001",
+		Created: time.Date(2026, 4, 29, 9, 0, 0, 0, time.UTC),
+		Body:    "buy milk\nfrom the corner store\n",
+	})
+	writeTaskFile(t, openDir, task.Task{
+		ID:      "open0002",
+		Created: time.Date(2026, 4, 29, 10, 0, 0, 0, time.UTC),
+		Body:    "fix the login bug\n",
+	})
+	writeTaskFile(t, closedDir, task.Task{
+		ID:        "clsd0001",
+		Created:   time.Date(2026, 4, 28, 8, 0, 0, 0, time.UTC),
+		Completed: time.Date(2026, 4, 29, 11, 0, 0, 0, time.UTC),
+		Body:      "ship the release\n",
+	})
+}
+
+// TestCompleteFragment_filtersByState confirms the filter argument
+// scopes which tasks are surfaced as completion candidates: FilterAll
+// returns every task, FilterOpen drops closed ones, and FilterClosed
+// drops open ones. This is what makes `close <Tab>` show only open
+// tasks and `reopen <Tab>` show only closed.
+func TestCompleteFragment_filtersByState(t *testing.T) {
+	completionFixture(t)
+
+	cases := []struct {
+		filter store.Filter
+		wantID []string
+	}{
+		{store.FilterAll, []string{"clsd0001", "open0001", "open0002"}},
+		{store.FilterOpen, []string{"open0001", "open0002"}},
+		{store.FilterClosed, []string{"clsd0001"}},
+	}
+	for _, c := range cases {
+		results, dir := completeFragment(c.filter)(&cobra.Command{}, nil, "")
+		if dir != cobra.ShellCompDirectiveNoFileComp {
+			t.Errorf("filter=%v: directive=%v, want ShellCompDirectiveNoFileComp", c.filter, dir)
+		}
+		got := completionIDs(results)
+		sort.Strings(got)
+		if !equalSlices(got, c.wantID) {
+			t.Errorf("filter=%v: ids=%v, want %v", c.filter, got, c.wantID)
+		}
+	}
+}
+
+// TestCompleteFragment_descriptions confirms that each candidate is
+// rendered as "<id>\t<first-line-of-body>", which is the format fish
+// (and zsh) use to show a description next to each completion in the
+// menu. Bodies span multiple lines on disk, so only the first line
+// must reach the shell.
+func TestCompleteFragment_descriptions(t *testing.T) {
+	completionFixture(t)
+
+	results, _ := completeFragment(store.FilterAll)(&cobra.Command{}, nil, "")
+	want := map[string]string{
+		"open0001": "buy milk",
+		"open0002": "fix the login bug",
+		"clsd0001": "ship the release",
+	}
+	for _, r := range results {
+		id, desc := splitCandidate(r)
+		if w, ok := want[id]; !ok {
+			t.Errorf("unexpected candidate id %q (full=%q)", id, r)
+		} else if desc != w {
+			t.Errorf("candidate %q: description=%q, want %q", id, desc, w)
+		}
+	}
+	if len(results) != len(want) {
+		t.Errorf("got %d candidates, want %d", len(results), len(want))
+	}
+}
+
+// TestCompleteFragment_skipsAfterFirstArg checks the second-arg
+// behaviour for two-argument commands like `update <fragment> <text>`:
+// once a fragment has been provided, the completion function returns no
+// candidates and suppresses filename fallback, so a stray <Tab> on the
+// free-form text arg does not flood the user with files from cwd.
+func TestCompleteFragment_skipsAfterFirstArg(t *testing.T) {
+	completionFixture(t)
+
+	results, dir := completeFragment(store.FilterAll)(&cobra.Command{}, []string{"open0001"}, "")
+	if len(results) != 0 {
+		t.Errorf("expected no candidates after first arg, got %v", results)
+	}
+	if dir != cobra.ShellCompDirectiveNoFileComp {
+		t.Errorf("directive=%v, want ShellCompDirectiveNoFileComp", dir)
+	}
+}
+
+func completionIDs(candidates []string) []string {
+	out := make([]string, 0, len(candidates))
+	for _, c := range candidates {
+		id, _ := splitCandidate(c)
+		out = append(out, id)
+	}
+	return out
+}
+
+func splitCandidate(s string) (id, desc string) {
+	for i := 0; i < len(s); i++ {
+		if s[i] == '\t' {
+			return s[:i], s[i+1:]
+		}
+	}
+	return s, ""
+}
+
+func equalSlices(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/cmd/edit.go
+++ b/cmd/edit.go
@@ -14,9 +14,10 @@ import (
 )
 
 var editCmd = &cobra.Command{
-	Use:   "edit <fragment>",
-	Short: "Open a task file in the configured editor",
-	Args:  cobra.ExactArgs(1),
+	Use:               "edit <fragment>",
+	Short:             "Open a task file in the configured editor",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment := args[0]
 		cfg, err := config.Load()

--- a/cmd/reopen.go
+++ b/cmd/reopen.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var reopenCmd = &cobra.Command{
-	Use:   "reopen <fragment>",
-	Short: "Move a task from closed back to open",
-	Args:  cobra.ExactArgs(1),
+	Use:               "reopen <fragment>",
+	Short:             "Move a task from closed back to open",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeFragment(store.FilterClosed),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment := args[0]
 		s, err := newStore()

--- a/cmd/research.go
+++ b/cmd/research.go
@@ -39,9 +39,10 @@ const (
 var researchRunFunc research.RunFunc = research.DefaultRun
 
 var researchCmd = &cobra.Command{
-	Use:   "research [<fragment>]",
-	Short: "Research one task or sweep every open task via headless claude agents",
-	Args:  cobra.MaximumNArgs(1),
+	Use:               "research [<fragment>]",
+	Short:             "Research one task or sweep every open task via headless claude agents",
+	Args:              cobra.MaximumNArgs(1),
+	ValidArgsFunction: completeFragment(store.FilterOpen),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		if len(args) == 1 && cmd.Flags().Changed("tag") {
 			return fmt.Errorf("--tag is not valid in single-task mode (drop the fragment to sweep all tagged tasks)")

--- a/cmd/show.go
+++ b/cmd/show.go
@@ -12,9 +12,10 @@ import (
 )
 
 var showCmd = &cobra.Command{
-	Use:   "show <fragment>",
-	Short: "Print a single task by id or description fragment",
-	Args:  cobra.ExactArgs(1),
+	Use:               "show <fragment>",
+	Short:             "Print a single task by id or description fragment",
+	Args:              cobra.ExactArgs(1),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment := args[0]
 		s, err := newStore()

--- a/cmd/tag.go
+++ b/cmd/tag.go
@@ -58,9 +58,10 @@ var tagLsCmd = &cobra.Command{
 }
 
 var tagAddCmd = &cobra.Command{
-	Use:   "add <fragment> <tag>",
-	Short: "Add a tag to an existing task",
-	Args:  cobra.ExactArgs(2),
+	Use:               "add <fragment> <tag>",
+	Short:             "Add a tag to an existing task",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment, rawTag := args[0], args[1]
 		s, err := newStore()
@@ -77,9 +78,10 @@ var tagAddCmd = &cobra.Command{
 }
 
 var tagRmCmd = &cobra.Command{
-	Use:   "rm <fragment> <tag>",
-	Short: "Remove a tag from an existing task",
-	Args:  cobra.ExactArgs(2),
+	Use:               "rm <fragment> <tag>",
+	Short:             "Remove a tag from an existing task",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment, rawTag := args[0], args[1]
 		s, err := newStore()

--- a/cmd/update.go
+++ b/cmd/update.go
@@ -2,12 +2,15 @@ package cmd
 
 import (
 	"github.com/spf13/cobra"
+
+	"github.com/jvcorredor/bytheway/internal/store"
 )
 
 var updateCmd = &cobra.Command{
-	Use:   "update <fragment> <new description>",
-	Short: "Replace the first body line of a task",
-	Args:  cobra.ExactArgs(2),
+	Use:               "update <fragment> <new description>",
+	Short:             "Replace the first body line of a task",
+	Args:              cobra.ExactArgs(2),
+	ValidArgsFunction: completeFragment(store.FilterAll),
 	RunE: func(cmd *cobra.Command, args []string) error {
 		fragment, newDescription := args[0], args[1]
 		s, err := newStore()

--- a/docs/src/content/docs/cli.md
+++ b/docs/src/content/docs/cli.md
@@ -245,3 +245,27 @@ For commands that take `<fragment>`, `btw` tries strategies in order and stops a
 If a strategy yields exactly one match, that is the result. If it yields more than one, the command exits non-zero with `ErrAmbiguous` and lists the candidates. If no strategy matches, it exits non-zero with `ErrNoMatch` and lists the current open tasks so the caller can pick.
 
 In `--format=json`, both error cases produce a JSON envelope with a stable `error` discriminator (`"ambiguous"` or `"no_match"`) so agents can branch without parsing prose. See [Agentic usage](./agentic.md) for the envelope shapes.
+
+## Shell completion
+
+Cobra emits completion scripts for bash, zsh, fish, and powershell via the hidden `completion <shell>` subcommand. Generate once and write to your shell's completions directory; the script delegates back to the binary at <kbd>Tab</kbd> time, so completions stay in sync as new subcommands ship without regenerating the script.
+
+```
+# fish
+btw completion fish > ~/.config/fish/completions/btw.fish
+
+# zsh (paths vary by setup)
+btw completion zsh > "${fpath[1]}/_btw"
+
+# bash
+btw completion bash > /etc/bash_completion.d/btw
+```
+
+For commands that take `<fragment>` — `show`, `close`, `reopen`, `edit`, `update`, `append`, `research`, `tag add`, `tag rm` — pressing <kbd>Tab</kbd> on the fragment position lists candidate tasks as `<id>\t<first body line>`, which fish and zsh render as the id alongside the task description. The candidate set is scoped per command:
+
+- `close`: open tasks only
+- `reopen`: closed tasks only
+- `research`: open tasks only
+- everything else: open and closed
+
+Subsequent positional arguments (e.g. the `<text>` of `update <fragment> <text>`) return no candidates and suppress filename fallback, so a stray <kbd>Tab</kbd> on the second arg does not flood the menu with files from the current directory.


### PR DESCRIPTION
## Summary

- Adds `ValidArgsFunction` to every subcommand that takes a `<fragment>` positional — `show`, `close`, `reopen`, `edit`, `update`, `append`, `research`, `tag add`, `tag rm`. Tab on the fragment lists tasks as `<id>\t<first-body-line>`, which fish/zsh render as the id alongside its description in the completion menu.
- Each command scopes its candidate set: `close` → open only, `reopen` → closed only, `research` → open only, everything else → all. Mirrors how each command's resolver scopes its lookup, so completion only ever offers tasks the command would actually act on.
- Second-position args on two-arg commands (e.g. `update <fragment> <text>`) return no candidates *and* `ShellCompDirectiveNoFileComp`, so a stray Tab on the free-form text arg does not flood the menu with files from cwd.
- Existing fish/zsh completion files delegate to the binary at Tab time via cobra's hidden `__complete` command. Users already on a generated completion script pick this up automatically — no regeneration needed when upgrading `bytheway`.
- Documents the feature under a new "Shell completion" section on the CLI reference page (per the same-PR docs rule in `CLAUDE.md`).

## Test plan

- [x] `just ci` passes (`fmt-check`, `vet`, `test`, `test-install`, `test-smoke-version`).
- [x] New `cmd/completion_test.go` covers filter scoping (`FilterAll`/`FilterOpen`/`FilterClosed`), the `id\tdescription` candidate format, and the second-arg suppression.
- [x] End-to-end smoke via `btw __complete <verb> ''`: with seeded open tasks, `show` and `close` return both, `reopen` returns none; directive is `ShellCompDirectiveNoFileComp` in every case.
- [ ] On a fish shell, run `btw show <Tab>` and confirm the menu shows id + description for each task. (Reviewer: requires regenerating `~/.config/fish/completions/btw.fish` only if you don't already have one — the script itself is binary-version-agnostic.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)